### PR TITLE
Add optional action param support

### DIFF
--- a/lib/brick_ftp/api/file.rb
+++ b/lib/brick_ftp/api/file.rb
@@ -1,7 +1,7 @@
 module BrickFTP
   module API
     class File < Base
-      endpoint :get,    :show,   '/api/rest/v1/files/%{path}'
+      endpoint :get,    :show,   '/api/rest/v1/files/%{path}', :action
       endpoint :delete, :delete, '/api/rest/v1/files/%{path}'
 
       attribute :id


### PR DESCRIPTION
Calling show_file(path: 'path/to/file', action: 'stat') will skip the download link and not trigger a download log

https://brickftp.com/docs/rest-api/file-operations/ (search for "action=stat")

The show_file method should probably be changed now as "id" isn't really an appropriate variable name for something that can accept a hash, but I wasn't sure how you'd want this to be changed for backwards compatibility reasons.

Thanks for creating this gem btw! It saved me a lot of time.