### PR TITLE
Allow to pass `action=stat` to Files: Download API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ Changelog
 
 - [#36](https://github.com/koshigoe/brick_ftp/pull/36) Add Changelog.
 - [#46](https://github.com/koshigoe/brick_ftp/pull/46) Add CLI.
+- [#53](https://github.com/koshigoe/brick_ftp/pull/53) Allow to pass `action=stat` to Files: Download API.
 
 ### Fixed Bugs:

--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -18,10 +18,11 @@ module BrickFTP
         data.map { |x| new(x.symbolize_keys) }
       end
 
-      def self.find(id)
+      def self.find(id, params: {})
         data = BrickFTP::HTTPClient.new.send(
           endpoints[:show][:http_method],
-          api_path_for(:show, id)
+          api_path_for(:show, id),
+          params: params
         )
         data.empty? ? nil : new(data.symbolize_keys)
       end

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -315,7 +315,7 @@ module BrickFTP
 
     # provides a download URL that will enable you to download a file.
     # @see https://brickftp.com/ja/docs/rest-api/file-operations/
-    # @param path path for file.
+    # @param path [String] path for file.
     # @return [BrickFTP::API::File] file object.
     def show_file(path)
       BrickFTP::API::File.find(path)

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -316,9 +316,12 @@ module BrickFTP
     # provides a download URL that will enable you to download a file.
     # @see https://brickftp.com/ja/docs/rest-api/file-operations/
     # @param path [String] path for file.
+    # @param omit_download_uri [Boolean] If true, omit download_uri. (Add query `action=stat`)
     # @return [BrickFTP::API::File] file object.
-    def show_file(path)
-      BrickFTP::API::File.find(path)
+    def show_file(path, omit_download_uri: false)
+      params = {}
+      params[:action] = 'stat' if omit_download_uri
+      BrickFTP::API::File.find(path, params: params)
     end
 
     # Move or renames a file or folder to the destination provided in the move_destination parameter.

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -315,10 +315,10 @@ module BrickFTP
 
     # provides a download URL that will enable you to download a file.
     # @see https://brickftp.com/ja/docs/rest-api/file-operations/
-    # @param id file id.
+    # @param path path for file.
     # @return [BrickFTP::API::File] file object.
-    def show_file(id)
-      BrickFTP::API::File.find(id)
+    def show_file(path)
+      BrickFTP::API::File.find(path)
     end
 
     # Move or renames a file or folder to the destination provided in the move_destination parameter.

--- a/lib/brick_ftp/http_client.rb
+++ b/lib/brick_ftp/http_client.rb
@@ -1,5 +1,6 @@
 require 'net/https'
 require 'json'
+require 'cgi'
 
 module BrickFTP
   class HTTPClient
@@ -35,7 +36,10 @@ module BrickFTP
     end
 
     def get(path, params: {}, headers: {})
-      case res = request(:get, path, params: params, headers: headers)
+      query = params.map { |k, v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}" }.join('&')
+      path = "#{path}?#{query}" unless query.empty?
+
+      case res = request(:get, path, headers: headers)
       when Net::HTTPSuccess
         res.body.nil? || res.body.empty? ? {} : JSON.parse(res.body)
       else

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -330,9 +330,18 @@ RSpec.describe BrickFTP::Client, type: :lib do
 
   describe 'File' do
     describe '#show_file' do
-      it 'delegate BrickFTP::API::File.find' do
-        expect(BrickFTP::API::File).to receive(:find).with('a/b')
-        described_class.new.show_file('a/b')
+      context 'omit_download_uri: false' do
+        it 'delegate BrickFTP::API::File.find' do
+          expect(BrickFTP::API::File).to receive(:find).with('a/b', params: {})
+          described_class.new.show_file('a/b')
+        end
+      end
+
+      context 'omit_download_uri: true' do
+        it 'delegate BrickFTP::API::File.find' do
+          expect(BrickFTP::API::File).to receive(:find).with('a/b', params: { action: 'stat' })
+          described_class.new.show_file('a/b', omit_download_uri: true)
+        end
       end
     end
 

--- a/spec/brick_ftp/http_client_spec.rb
+++ b/spec/brick_ftp/http_client_spec.rb
@@ -9,26 +9,50 @@ RSpec.describe BrickFTP::HTTPClient, type: :lib do
   end
 
   describe '#get' do
-    subject { described_class.new.get(path, params: {}, headers: { 'Depth' => 'infinity' }) }
+    subject { described_class.new.get(path, params: params, headers: { 'Depth' => 'infinity' }) }
 
     let(:path) { '/api/rest/v1/users.json' }
+    let(:params) { {} }
 
     context 'HTTP 200 OK' do
-      before do
-        stub_request(:get, 'https://koshigoe.brickftp.com/api/rest/v1/users.json')
-          .with(
-            basic_auth: ['xxxxxxxx', 'x'],
-            headers: {
-              'Content-Type' => 'application/json',
-              'User-Agent' => 'BrickFTP Client/0.1 (https://github.com/koshigoe/brick_ftp)',
-              'Depth' => 'infinity',
-            }
-          )
-          .to_return(body: { id: 'xxxxxxxx' }.to_json)
+      context 'without query string' do
+        before do
+          stub_request(:get, 'https://koshigoe.brickftp.com/api/rest/v1/users.json')
+            .with(
+              basic_auth: ['xxxxxxxx', 'x'],
+              headers: {
+                'Content-Type' => 'application/json',
+                'User-Agent' => 'BrickFTP Client/0.1 (https://github.com/koshigoe/brick_ftp)',
+                'Depth' => 'infinity',
+              }
+            )
+            .to_return(body: { id: 'xxxxxxxx' }.to_json)
+        end
+
+        it 'return data' do
+          is_expected.to eq('id' => 'xxxxxxxx')
+        end
       end
 
-      it 'return data' do
-        is_expected.to eq('id' => 'xxxxxxxx')
+      context 'with query string' do
+        let(:params) { { key: 'value' } }
+
+        before do
+          stub_request(:get, 'https://koshigoe.brickftp.com/api/rest/v1/users.json?key=value')
+            .with(
+              basic_auth: ['xxxxxxxx', 'x'],
+              headers: {
+                'Content-Type' => 'application/json',
+                'User-Agent' => 'BrickFTP Client/0.1 (https://github.com/koshigoe/brick_ftp)',
+                'Depth' => 'infinity',
+              }
+            )
+            .to_return(body: { id: 'xxxxxxxx' }.to_json)
+        end
+
+        it 'return data' do
+          is_expected.to eq('id' => 'xxxxxxxx')
+        end
       end
     end
 


### PR DESCRIPTION
Related: https://github.com/koshigoe/brick_ftp/pull/52

To add query string `action=stat` to API of download file.
https://brickftp.com/docs/rest-api/file-operations/

I add optional argument `omit_download_uri:` to `BrickFTP::Client#show_file`.

Without `action=stat`:

```
> BrickFTP::Client.new.show_file('path/to/file')
=> #<BrickFTP::API::File:0x007fe4262bdce0
 @crc32="1ff6c986",
 @download_uri="https://s3.amazonaws.com/objects.brickftp.com/metadata/...",
 @id=242031297,
 @md5="12b53425cdb8a865d103e59a6b518dc2",
 @mtime="2016-11-11T08:14:46+00:00",
 @path="path/to/file",
 @permissions="rwd",
 @provided_mtime="2016-11-01T07:50:13+00:00",
 @size=41171,
 @type="file">
```

With `action=stat`:

```
> BrickFTP::Client.new.show_file('path/to/file', omit_download_uri: true)
=> #<BrickFTP::API::File:0x007fe427905430
 @crc32="1ff6c986",
 @id=242031297,
 @md5="12b53425cdb8a865d103e59a6b518dc2",
 @mtime="2016-11-11T08:14:46+00:00",
 @path="path/to/file",
 @permissions="rwd",
 @provided_mtime="2016-11-01T07:50:13+00:00",
 @size=41171,
 @type="file">
```