### PR TITLE
Replace CGI.escape with URI.escape

### DIFF
--- a/lib/brick_ftp/api_component.rb
+++ b/lib/brick_ftp/api_component.rb
@@ -12,7 +12,7 @@ module BrickFTP
 
       path_params = build_path_params_from(params)
       escaped_path_params = path_params.each_with_object({}) do |(k, v), res|
-        res[k] = CGI.escape(v.to_s)
+        res[k] = URI.escape(v.to_s)
       end
 
       path = path_template.call(params) % escaped_path_params
@@ -41,7 +41,7 @@ module BrickFTP
       params = normalize_params(params)
 
       pairs = build_query_params_from(params).each_with_object([]) do |(k, v), res|
-        res << "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}"
+        res << "#{URI.escape(k.to_s)}=#{URI.escape(v.to_s)}"
       end
       pairs.join('&')
     end

--- a/lib/brick_ftp/http_client.rb
+++ b/lib/brick_ftp/http_client.rb
@@ -36,7 +36,7 @@ module BrickFTP
     end
 
     def get(path, params: {}, headers: {})
-      query = params.map { |k, v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}" }.join('&')
+      query = params.map { |k, v| "#{URI.escape(k.to_s)}=#{URI.escape(v.to_s)}" }.join('&')
       path = "#{path}?#{query}" unless query.empty?
 
       case res = request(:get, path, headers: headers)


### PR DESCRIPTION
close #55 
I was running into 404 errors on file show when the file had spaces in its filename.  After toying around with it I realized that BrickFTP formats their endpoints with URI style delimiters (URI's %20 rather than CGI's %26). 