### PR TITLE
Fix wrong path escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
 
 ### Fixed Bugs:
 
+- [#58](https://github.com/koshigoe/brick_ftp/pull/58) Fix wrong path escape
+    - reported by [terencedignon](https://github.com/terencedignon)
+
 
 [0.4.0](https://github.com/koshigoe/brick_ftp/compare/v0.3.8...v0.4.0)
 ----

--- a/lib/brick_ftp/api_component.rb
+++ b/lib/brick_ftp/api_component.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 module BrickFTP
   class APIComponent
     attr_reader :path_template, :query_keys
@@ -12,7 +14,7 @@ module BrickFTP
 
       path_params = build_path_params_from(params)
       escaped_path_params = path_params.each_with_object({}) do |(k, v), res|
-        res[k] = CGI.escape(v.to_s)
+        res[k] = ERB::Util.url_encode(v.to_s)
       end
 
       path = path_template.call(params) % escaped_path_params

--- a/spec/brick_ftp/api/file_spec.rb
+++ b/spec/brick_ftp/api/file_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe BrickFTP::API::File, type: :lib do
     context 'exists' do
       context 'without query action=stat' do
         before do
-          stub_request(:get, 'https://koshigoe.brickftp.com/api/rest/v1/files/Engineering+Candidates%2FJohn+Smith.docx')
+          stub_request(:get, 'https://koshigoe.brickftp.com/api/rest/v1/files/Engineering%20Candidates%2FJohn%20Smith.docx')
             .with(basic_auth: ['xxxxxxxx', 'x'])
             .to_return(body: file.to_json)
         end
@@ -54,7 +54,7 @@ RSpec.describe BrickFTP::API::File, type: :lib do
 
         before do
           file.delete('download_uri')
-          stub_request(:get, 'https://koshigoe.brickftp.com/api/rest/v1/files/Engineering+Candidates%2FJohn+Smith.docx?action=stat')
+          stub_request(:get, 'https://koshigoe.brickftp.com/api/rest/v1/files/Engineering%20Candidates%2FJohn%20Smith.docx?action=stat')
             .with(basic_auth: ['xxxxxxxx', 'x'])
             .to_return(body: file.to_json)
         end
@@ -81,7 +81,7 @@ RSpec.describe BrickFTP::API::File, type: :lib do
 
     context 'not exists' do
       before do
-        stub_request(:get, 'https://koshigoe.brickftp.com/api/rest/v1/files/Engineering+Candidates%2FJohn+Smith.docx')
+        stub_request(:get, 'https://koshigoe.brickftp.com/api/rest/v1/files/Engineering%20Candidates%2FJohn%20Smith.docx')
           .with(basic_auth: ['xxxxxxxx', 'x'])
           .to_return(body: '[]')
       end
@@ -99,7 +99,7 @@ RSpec.describe BrickFTP::API::File, type: :lib do
       let(:file) { described_class.new(path: 'Engineering Candidates/John Smith.docx') }
 
       before do
-        stub_request(:delete, 'https://koshigoe.brickftp.com/api/rest/v1/files/Engineering+Candidates%2FJohn+Smith.docx')
+        stub_request(:delete, 'https://koshigoe.brickftp.com/api/rest/v1/files/Engineering%20Candidates%2FJohn%20Smith.docx')
           .with(basic_auth: ['xxxxxxxx', 'x'])
           .to_return(body: '[]')
       end
@@ -115,7 +115,7 @@ RSpec.describe BrickFTP::API::File, type: :lib do
       let(:file) { described_class.new(path: 'Engineering Candidates') }
 
       before do
-        stub_request(:delete, 'https://koshigoe.brickftp.com/api/rest/v1/files/Engineering+Candidates')
+        stub_request(:delete, 'https://koshigoe.brickftp.com/api/rest/v1/files/Engineering%20Candidates')
           .with(basic_auth: ['xxxxxxxx', 'x'], headers: { 'Depth' => 'infinity' })
           .to_return(body: '[]')
       end

--- a/spec/brick_ftp/api/folder_spec.rb
+++ b/spec/brick_ftp/api/folder_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe BrickFTP::API::Folder, type: :lib do
     end
 
     before do
-      stub_request(:get, 'https://koshigoe.brickftp.com/api/rest/v1/folders/Engineering+Candidates%2FR%C3%A9sum%C3%A9s?page=1&per_page=10&search=Engineering%20Candidates%2F&sort_by%5Bmodified_at_datetime%5D=asc&sort_by%5Bpath%5D=asc&sort_by%5Bsize%5D=asc')
+      stub_request(:get, 'https://koshigoe.brickftp.com/api/rest/v1/folders/Engineering%20Candidates%2FR%C3%A9sum%C3%A9s?page=1&per_page=10&search=Engineering%20Candidates%2F&sort_by%5Bmodified_at_datetime%5D=asc&sort_by%5Bpath%5D=asc&sort_by%5Bsize%5D=asc')
         .with(basic_auth: ['xxxxxxxx', 'x'])
         .to_return(body: folders.to_json)
     end

--- a/spec/brick_ftp/api_component_spec.rb
+++ b/spec/brick_ftp/api_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BrickFTP::APIComponent, type: :lib do
 
   let(:params) do
     {
-      path: 'a/b/c.txt',
+      path: 'a/b/c include spaces.txt',
       page: 1,
       per_page: 1,
       search: 'a/',
@@ -26,7 +26,7 @@ RSpec.describe BrickFTP::APIComponent, type: :lib do
     subject { api_component.path(params) }
 
     context 'params is a Hash' do
-      it { is_expected.to eq '/api/rest/v1/folders/a%2Fb%2Fc.txt?page=1&per_page=1&search=a%2F&sort_by%5Bpath%5D=asc&sort_by%5Bsize%5D=asc&sort_by%5Bmodified_at_datetime%5D=asc' }
+      it { is_expected.to eq '/api/rest/v1/folders/a%2Fb%2Fc%20include%20spaces.txt?page=1&per_page=1&search=a%2F&sort_by%5Bpath%5D=asc&sort_by%5Bsize%5D=asc&sort_by%5Bmodified_at_datetime%5D=asc' }
     end
 
     context 'params is not a Hash' do
@@ -56,7 +56,7 @@ RSpec.describe BrickFTP::APIComponent, type: :lib do
 
     context 'params is a Hash' do
       it do
-        is_expected.to eq(path: 'a/b/c.txt')
+        is_expected.to eq(path: 'a/b/c include spaces.txt')
       end
     end
 


### PR DESCRIPTION
close #55

### Problem

Now, the path parameters escaped using `CGI.escape`.
Then, ` `(white space) is encoded to `+`.

In BrickFTP's API document.

>If special characters exist in the path name, encode them in UTF-8 first and then URL encode the bytes. For example, to list the contents of a folder with a complete path of Engineering Candidates/Résumés, a GET request would be sent to /folders/Engineering%20Candidates/R%c3%a9sum%c3%a9s.
> https://brickftp.com/docs/rest-api/file-operations/

It must be encoded to `%20`. Not `+`.

### Fix

- [x] Use `ERB::Util.url_encode` instead of `CGI.escape`

### TODO

- [ ] Bump version
- [x] Update Changelog
- [ ] Release