### PR TITLE
Allow to specify resource as ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog
 
 ### Enhancements:
 
+- [#65](https://github.com/koshigoe/brick_ftp/pull/65) Allow to specify resource as ID
+
 ### Fixed Bugs:
 
 

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -365,5 +365,13 @@ module BrickFTP
     def site_usage
       BrickFTP::API::SiteUsage.find
     end
+
+    private
+
+    def instantize_user(user_or_id)
+      return user_or_id if user_or_id.is_a?(BrickFTP::API::User)
+
+      BrickFTP::API::User.new(id: user_or_id)
+    end
   end
 end

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -344,11 +344,11 @@ module BrickFTP
 
     # Delete a file.
     # @see https://brickftp.com/ja/docs/rest-api/file-operations/
-    # @param file [BrickFTP::API::File] file object.
+    # @param file_or_path [BrickFTP::API::File, String] file object or file(folder) path.
     # @param recursive: [Boolean]
     # @return [Boolean] return true.
-    def delete_file(file, recursive: false)
-      file.destroy(recursive: recursive)
+    def delete_file(file_or_path, recursive: false)
+      instantize_file(file_or_path).destroy(recursive: recursive)
     end
 
     # Upload file.

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -265,11 +265,11 @@ module BrickFTP
 
     # Update an existing behavior.
     # @see https://brickftp.com/ja/docs/rest-api/behaviors/
-    # @param behavior [BrickFTP::API::Behavior] behavior object.
+    # @param behavior_or_id [BrickFTP::API::Behavior, Integer] behavior object or behavior id.
     # @param attributes [Hash] Behavior's attributes.
     # @return [BrickFTP::API::Behavior] behavior object.
-    def update_behavior(behavior, attributes)
-      behavior.update(attributes)
+    def update_behavior(behavior_or_id, attributes)
+      instantize_behavior(behavior_or_id).update(attributes)
     end
 
     # Delete a behavior.

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -215,10 +215,10 @@ module BrickFTP
 
     # Delete a bundle.
     # @see https://brickftp.com/ja/docs/rest-api/bundles/
-    # @param bundle [BrickFTP::API::Bundle] bundle object.
+    # @param bundle_or_id [BrickFTP::API::Bundle, Integer] bundle object or bundle id.
     # @return [Boolean] return true.
-    def delete_bundle(bundle)
-      bundle.destroy
+    def delete_bundle(bundle_or_id)
+      instantize_bundle(bundle_or_id).destroy
     end
 
     # List the contents of a bundle.

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -274,10 +274,10 @@ module BrickFTP
 
     # Delete a behavior.
     # @see https://brickftp.com/ja/docs/rest-api/behaviors/
-    # @param behavior [BrickFTP::API::Behavior] behavior object.
+    # @param behavior_or_id [BrickFTP::API::Behavior, Integer] behavior object or behavior id.
     # @return [Boolean] return true.
-    def delete_behavior(behavior)
-      behavior.destroy
+    def delete_behavior(behavior_or_id)
+      instantize_behavior(behavior_or_id).destroy
     end
 
     # shows the behaviors that apply to the given path.

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -106,10 +106,10 @@ module BrickFTP
 
     # Delete a permission.
     # @see https://brickftp.com/ja/docs/rest-api/permissions/
-    # @param permission [BrickFTP::API::Permission] permission object.
+    # @param permission_or_id [BrickFTP::API::Permission, Integer] permission object or permission id.
     # @return [Boolean] return true.
-    def delete_permission(permission)
-      permission.destroy
+    def delete_permission(permission_or_id)
+      instantize_permission(permission_or_id).destroy
     end
 
     # List all notifications on the current site.

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -373,5 +373,11 @@ module BrickFTP
 
       BrickFTP::API::User.new(id: user_or_id)
     end
+
+    def instantize_group(group_or_id)
+      return group_or_id if group_or_id.is_a?(BrickFTP::API::Group)
+
+      BrickFTP::API::Group.new(id: group_or_id)
+    end
   end
 end

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -47,10 +47,10 @@ module BrickFTP
 
     # Delete a user.
     # @see https://brickftp.com/ja/docs/rest-api/users/
-    # @param user [BrickFTP::API::User] user object.
+    # @param user_or_id [BrickFTP::API::User, Integer] user object or user id.
     # @return [Boolean] return true.
-    def delete_user(user)
-      user.destroy
+    def delete_user(user_or_id)
+      instantize_user(user_or_id).destroy
     end
 
     # List all groups on the current site.

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -385,5 +385,11 @@ module BrickFTP
 
       BrickFTP::API::Permission.new(id: permission_or_id)
     end
+
+    def instantize_notification(notification_or_id)
+      return notification_or_id if notification_or_id.is_a?(BrickFTP::API::Notification)
+
+      BrickFTP::API::Notification.new(id: notification_or_id)
+    end
   end
 end

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -403,5 +403,11 @@ module BrickFTP
 
       BrickFTP::API::Behavior.new(id: behavior_or_id)
     end
+
+    def instantize_file(file_or_path)
+      return file_or_path if file_or_path.is_a?(BrickFTP::API::File)
+
+      BrickFTP::API::File.new(path: file_or_path)
+    end
   end
 end

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -127,10 +127,10 @@ module BrickFTP
 
     # Delete a notification.
     # @see https://brickftp.com/ja/docs/rest-api/notifications/
-    # @param notification [BrickFTP::API::Notification] notification object.
+    # @param notification_or_id [BrickFTP::API::Notification, Integer] notification object or notification id.
     # @return [Boolean] return true.
-    def delete_notification(notification)
-      notification.destroy
+    def delete_notification(notification_or_id)
+      instantize_notification(notification_or_id).destroy
     end
 
     # Show the entire history for the current site.

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -397,5 +397,11 @@ module BrickFTP
 
       BrickFTP::API::Bundle.new(id: bundle_or_id)
     end
+
+    def instantize_behavior(behavior_or_id)
+      return behavior_or_id if behavior_or_id.is_a?(BrickFTP::API::Behavior)
+
+      BrickFTP::API::Behavior.new(id: behavior_or_id)
+    end
   end
 end

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -76,11 +76,11 @@ module BrickFTP
 
     # Update an existing group.
     # @see https://brickftp.com/ja/docs/rest-api/groups/
-    # @param group [BrickFTP::API::Group] group object.
+    # @param group_or_id [BrickFTP::API::Group, Integer] group object or group id.
     # @param attributes [Hash] Group's attributes.
     # @return [BrickFTP::API::Group] group object.
-    def update_group(group, attributes)
-      group.update(attributes)
+    def update_group(group_or_id, attributes)
+      instantize_group(group_or_id).update(attributes)
     end
 
     # Delete a group.

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -38,11 +38,11 @@ module BrickFTP
 
     # Update an existing user.
     # @see https://brickftp.com/ja/docs/rest-api/users/
-    # @param user [BrickFTP::API::User] user object.
+    # @param user_or_id [BrickFTP::API::User, Integer] user object or user id.
     # @param attributes [Hash] User's attributes.
     # @return [BrickFTP::API::User] user object.
-    def update_user(user, attributes)
-      user.update(attributes)
+    def update_user(user_or_id, attributes)
+      instantize_user(user_or_id).update(attributes)
     end
 
     # Delete a user.

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -379,5 +379,11 @@ module BrickFTP
 
       BrickFTP::API::Group.new(id: group_or_id)
     end
+
+    def instantize_permission(permission_or_id)
+      return permission_or_id if permission_or_id.is_a?(BrickFTP::API::Permission)
+
+      BrickFTP::API::Permission.new(id: permission_or_id)
+    end
   end
 end

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -85,10 +85,10 @@ module BrickFTP
 
     # Delete a group.
     # @see https://brickftp.com/ja/docs/rest-api/groups/
-    # @param group [BrickFTP::API::Group] group object.
+    # @param group_or_id [BrickFTP::API::Group, Integer] group object or group id.
     # @return [Boolean] return true.
-    def delete_group(group)
-      group.destroy
+    def delete_group(group_or_id)
+      instantize_group(group_or_id).destroy
     end
 
     # List all permissions on the current site.

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -391,5 +391,11 @@ module BrickFTP
 
       BrickFTP::API::Notification.new(id: notification_or_id)
     end
+
+    def instantize_bundle(bundle_or_id)
+      return bundle_or_id if bundle_or_id.is_a?(BrickFTP::API::Bundle)
+
+      BrickFTP::API::Bundle.new(id: bundle_or_id)
+    end
   end
 end

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -453,19 +453,39 @@ RSpec.describe BrickFTP::Client, type: :lib do
     end
 
     describe '#delete_file' do
-      let(:file) { BrickFTP::API::File.new(id: 'a/b') }
+      context 'given file as object' do
+        let(:file) { BrickFTP::API::File.new(path: 'a/b') }
 
-      context 'without options' do
-        it 'delegate BrickFTP::API::File#destroy' do
-          expect(file).to receive(:destroy).with(recursive: false)
-          described_class.new.delete_file(file)
+        context 'without options' do
+          it 'delegate BrickFTP::API::File#destroy' do
+            expect(file).to receive(:destroy).with(recursive: false)
+            described_class.new.delete_file(file)
+          end
+        end
+
+        context 'recursive: true' do
+          it 'delegate BrickFTP::API::File#destroy' do
+            expect(file).to receive(:destroy).with(recursive: true)
+            described_class.new.delete_file(file, recursive: true)
+          end
         end
       end
 
-      context 'recursive: true' do
-        it 'delegate BrickFTP::API::File#destroy' do
-          expect(file).to receive(:destroy).with(recursive: true)
-          described_class.new.delete_file(file, recursive: true)
+      context 'given file as path' do
+        let(:file) { 'a/b' }
+
+        context 'without options' do
+          it 'delegate BrickFTP::API::File#destroy' do
+            expect(BrickFTP::API::File).to receive_message_chain(:new, :destroy).with(path: 'a/b').with(recursive: false)
+            described_class.new.delete_file(file)
+          end
+        end
+
+        context 'recursive: true' do
+          it 'delegate BrickFTP::API::File#destroy' do
+            expect(BrickFTP::API::File).to receive_message_chain(:new, :destroy).with(path: 'a/b').with(recursive: true)
+            described_class.new.delete_file(file, recursive: true)
+          end
         end
       end
     end

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -359,10 +359,20 @@ RSpec.describe BrickFTP::Client, type: :lib do
     end
 
     describe '#delete_behavior' do
-      let(:behavior) { BrickFTP::API::Behavior.new(id: 1) }
-      it 'delegate BrickFTP::API::Behavior#destroy' do
-        expect(behavior).to receive(:destroy)
-        described_class.new.delete_behavior(behavior)
+      context 'given behavior as object' do
+        let(:behavior) { BrickFTP::API::Behavior.new(id: 1) }
+        it 'delegate BrickFTP::API::Behavior#destroy' do
+          expect(behavior).to receive(:destroy)
+          described_class.new.delete_behavior(behavior)
+        end
+      end
+
+      context 'given behavior as id' do
+        let(:behavior) { 1 }
+        it 'delegate BrickFTP::API::Behavior#destroy' do
+          expect(BrickFTP::API::Behavior).to receive_message_chain(:new, :destroy).with(id: 1).with(no_args)
+          described_class.new.delete_behavior(behavior)
+        end
       end
     end
 

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -160,10 +160,20 @@ RSpec.describe BrickFTP::Client, type: :lib do
     end
 
     describe '#delete_permission' do
-      let(:permission) { BrickFTP::API::Permission.new(id: 1) }
-      it 'delegate BrickFTP::API::Permission#destroy' do
-        expect(permission).to receive(:destroy)
-        described_class.new.delete_permission(permission)
+      context 'given permission as object' do
+        let(:permission) { BrickFTP::API::Permission.new(id: 1) }
+        it 'delegate BrickFTP::API::Permission#destroy' do
+          expect(permission).to receive(:destroy)
+          described_class.new.delete_permission(permission)
+        end
+      end
+
+      context 'given permission as id' do
+        let(:permission) { 1 }
+        it 'delegate BrickFTP::API::Permission#destroy' do
+          expect(BrickFTP::API::Permission).to receive_message_chain(:new, :destroy).with(id: 1).with(no_args)
+          described_class.new.delete_permission(permission)
+        end
       end
     end
   end

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -280,10 +280,20 @@ RSpec.describe BrickFTP::Client, type: :lib do
     end
 
     describe '#delete_bundle' do
-      let(:bundle) { BrickFTP::API::Bundle.new(id: 1) }
-      it 'delegate BrickFTP::API::Bundle#destroy' do
-        expect(bundle).to receive(:destroy)
-        described_class.new.delete_bundle(bundle)
+      context 'given bundle as object' do
+        let(:bundle) { BrickFTP::API::Bundle.new(id: 1) }
+        it 'delegate BrickFTP::API::Bundle#destroy' do
+          expect(bundle).to receive(:destroy)
+          described_class.new.delete_bundle(bundle)
+        end
+      end
+
+      context 'given bundle as id' do
+        let(:bundle) { 1 }
+        it 'delegate BrickFTP::API::Bundle#destroy' do
+          expect(BrickFTP::API::Bundle).to receive_message_chain(:new, :destroy).with(id: 1).with(no_args)
+          described_class.new.delete_bundle(bundle)
+        end
       end
     end
 

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -125,10 +125,20 @@ RSpec.describe BrickFTP::Client, type: :lib do
     end
 
     describe '#delete_group' do
-      let(:group) { BrickFTP::API::Group.new(id: 1) }
-      it 'delegate BrickFTP::API::Group#destroy' do
-        expect(group).to receive(:destroy)
-        described_class.new.delete_group(group)
+      context 'given group as object' do
+        let(:group) { BrickFTP::API::Group.new(id: 1) }
+        it 'delegate BrickFTP::API::Group#destroy' do
+          expect(group).to receive(:destroy)
+          described_class.new.delete_group(group)
+        end
+      end
+
+      context 'given group as id' do
+        let(:group) { 1 }
+        it 'delegate BrickFTP::API::Group#destroy' do
+          expect(BrickFTP::API::Group).to receive_message_chain(:new, :destroy).with(id: 1).with(no_args)
+          described_class.new.delete_group(group)
+        end
       end
     end
   end

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -105,11 +105,22 @@ RSpec.describe BrickFTP::Client, type: :lib do
     end
 
     describe '#update_group' do
-      let(:group) { BrickFTP::API::Group.new(id: 1) }
-      let(:attributes) { {} }
-      it 'delegate BrickFTP::API::Group#update' do
-        expect(group).to receive(:update).with(attributes)
-        described_class.new.update_group(group, attributes)
+      context 'given group as object' do
+        let(:group) { BrickFTP::API::Group.new(id: 1) }
+        let(:attributes) { {} }
+        it 'delegate BrickFTP::API::Group#update' do
+          expect(group).to receive(:update).with(attributes)
+          described_class.new.update_group(group, attributes)
+        end
+      end
+
+      context 'given group as id' do
+        let(:group) { 1 }
+        let(:attributes) { {} }
+        it 'delegate BrickFTP::API::Group#update' do
+          expect(BrickFTP::API::Group).to receive_message_chain(:new, :update).with(id: 1).with(attributes)
+          described_class.new.update_group(group, attributes)
+        end
       end
     end
 

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -62,10 +62,20 @@ RSpec.describe BrickFTP::Client, type: :lib do
     end
 
     describe '#delete_user' do
-      let(:user) { BrickFTP::API::User.new(id: 1) }
-      it 'delegate BrickFTP::API::User#destroy' do
-        expect(user).to receive(:destroy)
-        described_class.new.delete_user(user)
+      context 'given user as object' do
+        let(:user) { BrickFTP::API::User.new(id: 1) }
+        it 'delegate BrickFTP::API::User#destroy' do
+          expect(user).to receive(:destroy)
+          described_class.new.delete_user(user)
+        end
+      end
+
+      context 'given user as id' do
+        let(:user) { 1 }
+        it 'delegate BrickFTP::API::User#destroy' do
+          expect(BrickFTP::API::User).to receive_message_chain(:new, :destroy).with(id: 1).with(no_args)
+          described_class.new.delete_user(user)
+        end
       end
     end
   end

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -339,11 +339,22 @@ RSpec.describe BrickFTP::Client, type: :lib do
     end
 
     describe '#update_behavior' do
-      let(:behavior) { BrickFTP::API::Behavior.new(id: 1) }
-      let(:attributes) { {} }
-      it 'delegate BrickFTP::API::Behavior#update' do
-        expect(behavior).to receive(:update).with(attributes)
-        described_class.new.update_behavior(behavior, attributes)
+      context 'given behavior as object' do
+        let(:behavior) { BrickFTP::API::Behavior.new(id: 1) }
+        let(:attributes) { {} }
+        it 'delegate BrickFTP::API::Behavior#update' do
+          expect(behavior).to receive(:update).with(attributes)
+          described_class.new.update_behavior(behavior, attributes)
+        end
+      end
+
+      context 'given behavior as id' do
+        let(:behavior) { 1 }
+        let(:attributes) { {} }
+        it 'delegate BrickFTP::API::Behavior#update' do
+          expect(BrickFTP::API::Behavior).to receive_message_chain(:new, :update).with(id: 1).with(attributes)
+          described_class.new.update_behavior(behavior, attributes)
+        end
       end
     end
 

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -42,11 +42,22 @@ RSpec.describe BrickFTP::Client, type: :lib do
     end
 
     describe '#update_user' do
-      let(:user) { BrickFTP::API::User.new(id: 1) }
-      let(:attributes) { {} }
-      it 'delegate BrickFTP::API::User#update' do
-        expect(user).to receive(:update).with(attributes)
-        described_class.new.update_user(user, attributes)
+      context 'given user as object' do
+        let(:user) { BrickFTP::API::User.new(id: 1) }
+        let(:attributes) { {} }
+        it 'delegate BrickFTP::API::User#update' do
+          expect(user).to receive(:update).with(attributes)
+          described_class.new.update_user(user, attributes)
+        end
+      end
+
+      context 'given user as id' do
+        let(:user) { 1 }
+        let(:attributes) { {} }
+        it 'delegate BrickFTP::API::User#update' do
+          expect(BrickFTP::API::User).to receive_message_chain(:new, :update).with(id: 1).with(attributes)
+          described_class.new.update_user(user, attributes)
+        end
       end
     end
 

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -195,10 +195,20 @@ RSpec.describe BrickFTP::Client, type: :lib do
     end
 
     describe '#delete_notification' do
-      let(:notification) { BrickFTP::API::Notification.new(id: 1) }
-      it 'delegate BrickFTP::API::Notification#destroy' do
-        expect(notification).to receive(:destroy)
-        described_class.new.delete_notification(notification)
+      context 'given notification as object' do
+        let(:notification) { BrickFTP::API::Notification.new(id: 1) }
+        it 'delegate BrickFTP::API::Notification#destroy' do
+          expect(notification).to receive(:destroy)
+          described_class.new.delete_notification(notification)
+        end
+      end
+
+      context 'given notification as id' do
+        let(:notification) { 1 }
+        it 'delegate BrickFTP::API::Notification#destroy' do
+          expect(BrickFTP::API::Notification).to receive_message_chain(:new, :destroy).with(id: 1).with(no_args)
+          described_class.new.delete_notification(notification)
+        end
       end
     end
   end


### PR DESCRIPTION
The methods `BrickFTP::Client#{update,delete}_*` take argument as instance of `BrickFTP::API::{Resource}` to specify resource.

To more useful, I allow to specify resource as identifier like ID or path.