### PR TITLE
Fix wrong API document.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog
 
 ### Fixed Bugs:
 
+- [#67](https://github.com/koshigoe/brick_ftp/pull/67) Fix wrong API document.
+
 
 [v0.5.0](https://github.com/koshigoe/brick_ftp/compare/v0.4.2...v0.5.0)
 ----

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -354,7 +354,7 @@ module BrickFTP
     # Upload file.
     # @see https://brickftp.com/ja/docs/rest-api/file-uploading/
     # @param path [String]
-    # @param source [String] path for source file.
+    # @param source [IO] source `data` (not `path`) to upload
     # @return [BrickFTP::API::FileUpload]
     def upload_file(path:, source:)
       BrickFTP::API::FileOperation::Upload.create(path: path, source: source)


### PR DESCRIPTION
About `BrickFTP::CLient#upload_file`'s second argument.

It's not path string.
It must be an IO object.

Example
----

```
$ bin/console
>> BrickFTP.configure { |c| c.subdomain = 'SUBDOMAIN' }
>> BrickFTP::API::Authentication.login('ID', 'PASSWORD')
>> client = BrickFTP::Client.new
>> open('./Gemfile') { |f| client.upload_file(path: '/test-koshigoe/Gemfile', source: f) }
```