### PR TITLE
sanitize instance variable names

### DIFF
--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -40,7 +40,7 @@ module BrickFTP
       end
 
       def initialize(params = {})
-        params.each { |k, v| instance_variable_set(:"@#{k}", v) }
+        params.each { |k, v| instance_variable_set(:"@#{sanitize_instance_variable_name(k)}", v) }
       end
 
       def update(params = {})
@@ -74,6 +74,12 @@ module BrickFTP
 
       def to_json
         as_json.to_json
+      end
+
+      private
+
+      def sanitize_instance_variable_name(name)
+        name.to_s.gsub(/\W/, '')
       end
     end
   end

--- a/spec/brick_ftp/api/base_spec.rb
+++ b/spec/brick_ftp/api/base_spec.rb
@@ -69,4 +69,10 @@ RSpec.describe BrickFTP::API::Base do
 
     it { is_expected.to eq({ id: '1', value: 'v' }.to_json) }
   end
+
+  describe '#sanitize_instance_variable_name' do
+    it 'should not error on params with question marks' do
+      expect{api.new(subfolders_locked?: true)}.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
close #68 

BrickFTP added `:subfolders_locked?` to `BrickFTP::Client.list_folders`'s payload, breaking the initializer in base.rb.  This pr makes sure all params are sanitized before they are set as instance variables. 