### PR TITLE
Improve accessor of API properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Changelog
 
 ### Fixed Bugs:
 
+### Breaking Changes:
+
+- [#72](https://github.com/koshigoe/brick_ftp/pull/72) Improve accessor of API properties
+    - Cannot access some API properties named same as methods of Ruby's Object.
+        - e.g. `send` property of [File Uploading](https://brickftp.com/docs/rest-api/file-uploading/)
+        - Use `#properties` to access properties
+
 
 [v0.5.1](https://github.com/koshigoe/brick_ftp/compare/v0.5.0...v0.5.1)
 ----

--- a/lib/brick_ftp/api/authentication/session.rb
+++ b/lib/brick_ftp/api/authentication/session.rb
@@ -15,7 +15,7 @@ module BrickFTP
 
         def destroy
           super.tap do
-            @id = nil
+            delete_property(:id)
             BrickFTP.config.session = nil
           end
         end

--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -39,6 +39,7 @@ module BrickFTP
         new(data.symbolize_keys)
       end
 
+      # @return [Hash{String => Object}] Key Value pairs of API properties
       attr_reader :properties
 
       def initialize(params = {})

--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -92,6 +92,16 @@ module BrickFTP
       def read_property(key)
         properties[key.to_s]
       end
+
+      def respond_to_missing?(method_name, _include_private)
+        self.class.attributes.include?(method_name.to_sym)
+      end
+
+      def method_missing(method_name, *args)
+        super unless self.class.attributes.include?(method_name.to_sym)
+
+        read_property(method_name)
+      end
     end
   end
 end

--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -93,6 +93,10 @@ module BrickFTP
         properties[key.to_s]
       end
 
+      def delete_property(key)
+        properties.delete(key.to_s)
+      end
+
       def respond_to_missing?(method_name, _include_private)
         self.class.attributes.include?(method_name.to_sym)
       end

--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -82,10 +82,6 @@ module BrickFTP
 
       private
 
-      def sanitize_instance_variable_name(name)
-        name.to_s.gsub(/\W/, '')
-      end
-
       def write_property(key, value)
         properties[key.to_s] = value
       end

--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -39,8 +39,11 @@ module BrickFTP
         new(data.symbolize_keys)
       end
 
+      attr_reader :properties
+
       def initialize(params = {})
-        params.each { |k, v| instance_variable_set(:"@#{sanitize_instance_variable_name(k)}", v) }
+        @properties = {}
+        params.each { |k, v| write_property(k, v) }
       end
 
       def update(params = {})
@@ -51,7 +54,7 @@ module BrickFTP
           self.class.api_path_for(:update, self),
           params: self.class.api_component_for(:update).except_path_and_query(params)
         )
-        data.each { |k, v| instance_variable_set(:"@#{k}", v) }
+        data.each { |k, v| write_property(k, v) }
 
         self
       end
@@ -80,6 +83,14 @@ module BrickFTP
 
       def sanitize_instance_variable_name(name)
         name.to_s.gsub(/\W/, '')
+      end
+
+      def write_property(key, value)
+        properties[key.to_s] = value
+      end
+
+      def read_property(key)
+        properties[key.to_s]
       end
     end
   end

--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -73,7 +73,7 @@ module BrickFTP
       end
 
       def as_json
-        self.class.attributes.each_with_object({}) { |name, res| res[name] = send(name) }
+        self.class.attributes.each_with_object({}) { |name, res| res[name] = read_property(name) }
       end
 
       def to_json

--- a/lib/brick_ftp/api/folder.rb
+++ b/lib/brick_ftp/api/folder.rb
@@ -14,6 +14,7 @@ module BrickFTP
       attribute :md5
       attribute :provided_mtime
       attribute :permissions
+      attribute :subfolders_locked?
     end
   end
 end

--- a/lib/brick_ftp/api_definition.rb
+++ b/lib/brick_ftp/api_definition.rb
@@ -37,7 +37,6 @@ module BrickFTP
         else
           readonly_attributes << name.to_sym
         end
-        attr_reader name.to_s.tr('-', '_')
       end
 
       # Return all attributes.

--- a/spec/brick_ftp/api/base_spec.rb
+++ b/spec/brick_ftp/api/base_spec.rb
@@ -69,10 +69,4 @@ RSpec.describe BrickFTP::API::Base do
 
     it { is_expected.to eq({ id: '1', value: 'v' }.to_json) }
   end
-
-  describe '#sanitize_instance_variable_name' do
-    it 'should not error on params with question marks' do
-      expect{api.new(subfolders_locked?: true)}.to_not raise_error
-    end
-  end
 end

--- a/spec/brick_ftp/api/base_spec.rb
+++ b/spec/brick_ftp/api/base_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe BrickFTP::API::Base do
 
       attribute :id
       attribute :value
+      attribute :send
     end
   end
 
@@ -61,12 +62,27 @@ RSpec.describe BrickFTP::API::Base do
   describe '#as_json' do
     subject { api.new(id: '1', value: 'v').as_json }
 
-    it { is_expected.to eq(id: '1', value: 'v') }
+    it { is_expected.to eq(id: '1', value: 'v', send: nil) }
   end
 
   describe '#to_json' do
     subject { api.new(id: '1', value: 'v').to_json }
 
-    it { is_expected.to eq({ id: '1', value: 'v' }.to_json) }
+    it { is_expected.to eq({ id: '1', value: 'v', send: nil }.to_json) }
+  end
+
+  describe '#properties' do
+    subject { api.new(id: 1, value: 'v', send: 's').properties }
+
+    it { is_expected.to eq('id' => 1, 'value' => 'v', 'send' => 's') }
+  end
+
+  describe 'accessor' do
+    subject { api.new(id: 1, value: 'v', send: 's') }
+
+    it { expect(subject.id).to eq 1 }
+    it { expect(subject.value).to eq 'v' }
+    it { expect { subject.send }.to raise_error(ArgumentError) }
+    it { expect(subject.properties['send']).to eq 's' }
   end
 end

--- a/spec/brick_ftp/api/file_operation/upload_spec.rb
+++ b/spec/brick_ftp/api/file_operation/upload_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe BrickFTP::API::FileOperation::Upload, type: :lib do
         expect(upload.partsize).to eq 5242880
         expect(upload.part_number).to eq 1
         expect(upload.available_parts).to eq 10000
-        expect(upload.send).to eq("partsize" => "required-parameter Content-Length", "partdata" => "body")
+        expect(upload.properties['send']).to eq("partsize" => "required-parameter Content-Length", "partdata" => "body")
         expect(upload.headers).to eq({})
         expect(upload.parameters).to eq({})
         expect(upload.id).to eq 1

--- a/spec/brick_ftp/api/folder_spec.rb
+++ b/spec/brick_ftp/api/folder_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe BrickFTP::API::Folder, type: :lib do
           "md5" => nil,
           'provided_mtime' => '2014-05-15T20:26:18+00:00',
           'permissions' => 'rwd',
+          'subfolders_locked?' => false,
         },
         {
           "id" => 2,
@@ -43,6 +44,7 @@ RSpec.describe BrickFTP::API::Folder, type: :lib do
           "md5" => "b67236f5bcd29d1307d574fb9fe585b5",
           'provided_mtime' => '2014-05-15T18:34:51+00:00',
           'permissions' => 'rwd',
+          'subfolders_locked?' => false,
         },
         {
           "id" => 3,
@@ -55,6 +57,7 @@ RSpec.describe BrickFTP::API::Folder, type: :lib do
           "md5" => "02c442ecc0d499bf443fa8fd444c2933",
           'provided_mtime' => '2014-05-15T18:36:03+00:00',
           'permissions' => 'rwd',
+          'subfolders_locked?' => false,
         }
       ]
     end
@@ -81,6 +84,7 @@ RSpec.describe BrickFTP::API::Folder, type: :lib do
       expect(folders.last.md5).to eq "02c442ecc0d499bf443fa8fd444c2933"
       expect(folders.last.provided_mtime).to eq '2014-05-15T18:36:03+00:00'
       expect(folders.last.permissions).to eq 'rwd'
+      expect(folders.last.subfolders_locked?).to eq false
     end
   end
 


### PR DESCRIPTION
resolve #71

Why
----

Now, accessors of API properties is implemented using `read_accessor`.
But, It insecure and buggy. If including disallowed characters like `?`, program raise exception.

How
----

To avoid problem, it should store API properties to object like Hash (or proxy object).

Breaking Changes
----

- Can't access to `send` property of [File Uploading](https://brickftp.com/docs/rest-api/file-uploading/) directly


