### PR TITLE
[75] Allow to initialize config data even if it can't expand path `~`

### DIFF
--- a/lib/brick_ftp/configuration.rb
+++ b/lib/brick_ftp/configuration.rb
@@ -38,7 +38,6 @@ module BrickFTP
     DEFAULT_READ_TIMEOUT = 30
 
     DEFAULT_PROFILE = 'global'.freeze
-    CONFIG_FILE_PATH = File.expand_path('~/.brick_ftp/config').freeze
     # Name of storable configurations. (TODO: log_path, log_level, log_formatter)
     STORABLE_CONFIGURATION_KEYS = %w(subdomain api_key open_timeout read_timeout).freeze
 
@@ -55,6 +54,7 @@ module BrickFTP
       # couldn't find login name -- expanding `~'
       nil
     end
+    CONFIG_FILE_PATH = default_config_file_path
 
     def initialize(profile: DEFAULT_PROFILE, config_file_path: CONFIG_FILE_PATH)
       @profile = profile
@@ -107,7 +107,7 @@ module BrickFTP
     attr_reader :inifile, :dirty_attributes
 
     def load_config_file(config_file_path)
-      @inifile = if File.exist?(config_file_path)
+      @inifile = if config_file_path && File.exist?(config_file_path)
                    IniFile.load(config_file_path, encoding: 'UTF-8')
                  else
                    IniFile.new(filename: config_file_path, encoding: 'UTF-8')

--- a/lib/brick_ftp/configuration.rb
+++ b/lib/brick_ftp/configuration.rb
@@ -49,6 +49,13 @@ module BrickFTP
       end
     end
 
+    def self.default_config_file_path
+      File.expand_path('~/.brick_ftp/config')
+    rescue ArgumentError
+      # couldn't find login name -- expanding `~'
+      nil
+    end
+
     def initialize(profile: DEFAULT_PROFILE, config_file_path: CONFIG_FILE_PATH)
       @profile = profile
       @config_file_path = config_file_path

--- a/spec/brick_ftp/configuration_spec.rb
+++ b/spec/brick_ftp/configuration_spec.rb
@@ -1,6 +1,23 @@
 require 'spec_helper'
 
 RSpec.describe BrickFTP::Configuration, type: :lib do
+  describe '.default_config_file_path' do
+    subject { described_class.default_config_file_path }
+
+    context 'with $HOME' do
+      it 'return $HOME/.brick_ftp/config' do
+        is_expected.to eq "#{ENV['HOME']}/.brick_ftp/config"
+      end
+    end
+
+    context 'without $HOME' do
+      it 'return nil' do
+        expect(File).to receive(:expand_path).with('~/.brick_ftp/config').and_raise(ArgumentError)
+        is_expected.to be_nil
+      end
+    end
+  end
+
   describe '#initialize' do
     subject { described_class.new(options) }
 

--- a/spec/brick_ftp/configuration_spec.rb
+++ b/spec/brick_ftp/configuration_spec.rb
@@ -23,9 +23,7 @@ RSpec.describe BrickFTP::Configuration, type: :lib do
 
     let(:options) { {} }
 
-    context 'inifile does not exist' do
-      before { options[:config_file_path] = File.expand_path('../../data/config-not-exist', __FILE__) }
-
+    shared_examples_for 'inifile does not exist' do
       context 'with environment variable' do
         around do |example|
           begin
@@ -68,6 +66,16 @@ RSpec.describe BrickFTP::Configuration, type: :lib do
       it 'set read_timeout default value' do
         expect(subject.read_timeout).to eq 30
       end
+    end
+
+    context 'config file path is wrong' do
+      before { options[:config_file_path] = File.expand_path('../../data/config-not-exist', __FILE__) }
+      it_behaves_like 'inifile does not exist'
+    end
+
+    context 'config file path is nil' do
+      before { options[:config_file_path] = nil }
+      it_behaves_like 'inifile does not exist'
     end
 
     context 'inifile exists' do


### PR DESCRIPTION
#75 

Why
----

If user does not have HOME directory, the `File.expand_path('~')` will raise `ArgumentError('couldn't find login name -- expanding `~'')`.
So, the following code will raise unexpected exception.

https://github.com/koshigoe/brick_ftp/blob/2c2eb041d73d16ed20be33929510c61bb1479f46/lib/brick_ftp/configuration.rb#L41

How
----

If user does not have HOME directory, it set `nil` value as default config path.
  
MEMO
----

Maybe, the config file is not needed. 
It may unnecessary complexity.