### PR TITLE
Making 3 separate methods fo each upload step

### DIFF
--- a/lib/brick_ftp/api/file_operation/upload.rb
+++ b/lib/brick_ftp/api/file_operation/upload.rb
@@ -44,22 +44,22 @@ module BrickFTP
           new(step1.merge(step3).symbolize_keys)
         end
         
-        def self.step1(path:, ref: nil, partNumber: nil)
+        def self.step1(path:, ref: nil, part_number: nil)
           api_client = BrickFTP::HTTPClient.new
 
-          if ref.nil? || partNumber.nil?
+          if ref.nil? || part_number.nil?
             step1 = api_client.post(api_path_for(:create, path: path), params: { action: 'put' })
           else
-            step1 = api_client.post(api_path_for(:create, path: path), params: { action: 'put', ref: ref, part: "#{partNumber}" })
+            step1 = api_client.post(api_path_for(:create, path: path), params: { action: 'put', ref: ref, part: part_number })
           end
 
           step1.symbolize_keys
         end
 
-        def self.step2(source:, uploadUri:)
-          upload_uri = URI.parse(uploadUri)
-          upload_client = BrickFTP::HTTPClient.new(upload_uri.host)
-          upload_client.put(uploadUri, params: source)
+        def self.step2(source:, upload_uri:)
+          upload_parsed_uri = URI.parse(uploadUri)
+          upload_client = BrickFTP::HTTPClient.new(upload_parsed_uri.host)
+          upload_client.put(upload_uri, params: source)
         end
 
         def self.step3(path:, ref:)

--- a/lib/brick_ftp/api/file_operation/upload.rb
+++ b/lib/brick_ftp/api/file_operation/upload.rb
@@ -43,6 +43,31 @@ module BrickFTP
 
           new(step1.merge(step3).symbolize_keys)
         end
+        
+        def self.step1(path:, ref: nil, partNumber: nil)
+          api_client = BrickFTP::HTTPClient.new
+
+          if ref.nil? || partNumber.nil?
+            step1 = api_client.post(api_path_for(:create, path: path), params: { action: 'put' })
+          else
+            step1 = api_client.post(api_path_for(:create, path: path), params: { action: 'put', ref: ref, part: "#{partNumber}" })
+          end
+
+          step1.symbolize_keys
+        end
+
+        def self.step2(source:, uploadUri:)
+          upload_uri = URI.parse(uploadUri)
+          upload_client = BrickFTP::HTTPClient.new(upload_uri.host)
+          upload_client.put(uploadUri, params: source)
+        end
+
+        def self.step3(path:, ref:)
+          api_client = BrickFTP::HTTPClient.new
+          step3 = api_client.post(api_path_for(:create, path: path), params: { action: 'end', ref: ref })
+
+          new(step3.symbolize_keys)
+        end
       end
     end
   end


### PR DESCRIPTION
Splitting the create method into 3 functions that each represents a file upload step as per the BrickFtp API