### PR TITLE
Allow `BrickFTP::Client#upload_file` to multi part uploading

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,7 @@ Metrics/LineLength:
   URISchemes:
     - http
     - https
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 ### Enhancements:
 
 - [#80](https://github.com/koshigoe/brick_ftp/pull/80) Use Rubocop.
+- [#85](https://github.com/koshigoe/brick_ftp/pull/85) Allow `BrickFTP::Client#upload_file` to multi part uploading.
 
 ### Fixed Bugs:
 

--- a/lib/brick_ftp.rb
+++ b/lib/brick_ftp.rb
@@ -40,6 +40,8 @@ require 'brick_ftp/cli'
 require 'brick_ftp/cli/config'
 require 'brick_ftp/cli/site'
 require 'brick_ftp/cli/main'
+require 'brick_ftp/utils'
+require 'brick_ftp/utils/chunk_io'
 
 module BrickFTP
   # https://brickftp.com/redundancy/

--- a/lib/brick_ftp/api/file_operation/upload.rb
+++ b/lib/brick_ftp/api/file_operation/upload.rb
@@ -31,17 +31,34 @@ module BrickFTP
         attribute :part, writable: true
         attribute :restart, writable: true
 
-        def self.create(path:, source:)
+        # Upload file.
+        #
+        # @see https://brickftp.com/docs/rest-api/file-uploading/
+        # @param [String] path Remote file path.
+        # @param [IO] source Source `data` (not `path`) to upload.
+        # @param [Integer] chunk_size Size of chunk to multi-part upload.
+        # @return [BrickFTP::API::FileOperation::Upload] An instance of BrickFTP::API::FileOperation::Upload.
+        #
+        def self.create(path:, source:, chunk_size: nil)
           api_client = BrickFTP::HTTPClient.new
-          step1 = api_client.post(api_path_for(:create, path: path), params: { action: 'put' })
+          chunk_io = BrickFTP::Utils::ChunkIO.new(source, chunk_size: chunk_size)
 
-          upload_uri = URI.parse(step1['upload_uri'])
-          upload_client = BrickFTP::HTTPClient.new(upload_uri.host)
-          upload_client.put(step1['upload_uri'], params: source)
+          ref = nil
+          params_for_request_upload_url = { action: 'put' }
+          upload_info = {}
+          chunk_io.each.with_index(1) do |chunk, part|
+            params_for_request_upload_url.update(part: part, ref: ref) if part > 1
+            upload_info = api_client.post(api_path_for(:create, path: path), params: params_for_request_upload_url)
+            ref = upload_info['ref']
 
-          step3 = api_client.post(api_path_for(:create, path: path), params: { action: 'end', ref: step1['ref'] })
+            upload_uri = URI.parse(upload_info['upload_uri'])
+            upload_client = BrickFTP::HTTPClient.new(upload_uri.host)
+            upload_client.put(upload_info['upload_uri'], params: chunk)
+          end
 
-          new(step1.merge(step3).symbolize_keys)
+          uploaded_info = api_client.post(api_path_for(:create, path: path), params: { action: 'end', ref: ref })
+
+          new(upload_info.merge(uploaded_info).symbolize_keys)
         end
       end
     end

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -364,9 +364,10 @@ module BrickFTP
     # @see https://brickftp.com/ja/docs/rest-api/file-uploading/
     # @param path [String]
     # @param source [IO] source `data` (not `path`) to upload
+    # @param chunk_size [Integer] Size of chunk to multi-part upload.
     # @return [BrickFTP::API::FileUpload]
-    def upload_file(path:, source:)
-      BrickFTP::API::FileOperation::Upload.create(path: path, source: source)
+    def upload_file(path:, source:, chunk_size: nil)
+      BrickFTP::API::FileOperation::Upload.create(path: path, source: source, chunk_size: chunk_size)
     end
 
     # Get usage of site.

--- a/lib/brick_ftp/utils.rb
+++ b/lib/brick_ftp/utils.rb
@@ -1,0 +1,4 @@
+module BrickFTP
+  module Utils
+  end
+end

--- a/lib/brick_ftp/utils/chunk_io.rb
+++ b/lib/brick_ftp/utils/chunk_io.rb
@@ -1,0 +1,39 @@
+module BrickFTP
+  module Utils
+    class ChunkIO
+      attr_reader :io
+
+      # Wrap IO object.
+      #
+      # @param [IO] io an IO object.
+      #
+      def initialize(io)
+        @io = io
+      end
+
+      # Iterate with chunked IO object.
+      #
+      # @param [Integer] chunk_size Size of chunk.
+      # @yield [chunk] Give a chunk IO object to block.
+      # @yieldparam [StringIO] chunk a chunked IO object.
+      #
+      def each_chunk(chunk_size: nil)
+        if chunk_size
+          offset = 0
+          loop do
+            chunk = StringIO.new
+            copied = IO.copy_stream(io, chunk, chunk_size, offset)
+            break if copied.zero?
+
+            offset += copied
+            chunk.rewind
+
+            yield chunk if copied
+          end
+        else
+          yield io
+        end
+      end
+    end
+  end
+end

--- a/lib/brick_ftp/utils/chunk_io.rb
+++ b/lib/brick_ftp/utils/chunk_io.rb
@@ -1,37 +1,52 @@
 module BrickFTP
   module Utils
     class ChunkIO
-      attr_reader :io
+      include Enumerable
+
+      attr_reader :io, :chunk_size
 
       # Wrap IO object.
       #
       # @param [IO] io an IO object.
+      # @param [Integer] chunk_size Size of chunk.
       #
-      def initialize(io)
+      def initialize(io, chunk_size: nil)
         @io = io
+        @chunk_size = chunk_size
       end
 
       # Iterate with chunked IO object.
       #
-      # @param [Integer] chunk_size Size of chunk.
       # @yield [chunk] Give a chunk IO object to block.
       # @yieldparam [StringIO] chunk a chunked IO object.
       #
-      def each_chunk(chunk_size: nil)
+      def each(&block)
+        return enum_for(__method__) unless block
+
         if chunk_size
-          offset = 0
-          loop do
-            chunk = StringIO.new
-            copied = IO.copy_stream(io, chunk, chunk_size, offset)
-            break if copied.zero?
-
-            offset += copied
-            chunk.rewind
-
-            yield chunk if copied
-          end
+          each_chunk(&block)
         else
-          yield io
+          whole(&block)
+        end
+      end
+
+      private
+
+      def whole
+        yield io
+      end
+
+      def each_chunk
+        offset = 0
+        loop do
+          chunk = StringIO.new
+          copied = IO.copy_stream(io, chunk, chunk_size, offset)
+          break if copied.zero?
+
+          offset += copied
+          chunk.rewind
+
+          yield chunk
         end
       end
     end

--- a/lib/brick_ftp/utils/chunk_io.rb
+++ b/lib/brick_ftp/utils/chunk_io.rb
@@ -1,3 +1,5 @@
+require 'tempfile'
+
 module BrickFTP
   module Utils
     class ChunkIO
@@ -37,16 +39,19 @@ module BrickFTP
       end
 
       def each_chunk
+        eof = false
         offset = 0
-        loop do
-          chunk = StringIO.new
-          copied = IO.copy_stream(io, chunk, chunk_size, offset)
-          break if copied.zero?
+        until eof
+          Tempfile.create do |chunk|
+            copied = IO.copy_stream(io, chunk, chunk_size, offset)
+            eof = copied.zero?
+            next if eof
 
-          offset += copied
-          chunk.rewind
+            offset += copied
+            chunk.rewind
 
-          yield chunk
+            yield chunk
+          end
         end
       end
     end

--- a/spec/brick_ftp/api/file_operation/upload_spec.rb
+++ b/spec/brick_ftp/api/file_operation/upload_spec.rb
@@ -4,12 +4,13 @@ RSpec.describe BrickFTP::API::FileOperation::Upload, type: :lib do
   before { BrickFTP.config.api_key = 'xxxxxxxx' }
 
   describe '.create' do
-    subject { described_class.create(path: 'NewFile.txt', source: source) }
+    subject { described_class.create(path: 'NewFile.txt', source: source, chunk_size: chunk_size) }
 
     context 'success' do
       let(:source) { open('spec/data/file_upload/source.txt') }
 
       context 'single part upload' do
+        let(:chunk_size) { nil }
         let(:step1) do
           {
             'ref' => 'put-378670',
@@ -82,10 +83,114 @@ RSpec.describe BrickFTP::API::FileOperation::Upload, type: :lib do
           expect(upload.md5).to eq nil
         end
       end
+
+      context 'multi part upload' do
+        let(:chunk_size) { 21 }
+        let(:step1_1) do
+          {
+            'ref' => 'put-378670',
+            'path' => 'NewFile.txt',
+            'action' => 'put/write',
+            'ask_about_overwrites' => false,
+            'http_method' => 'PUT',
+            'upload_uri' => 'https://s3.amazonaws.com/objects.brickftp.com/metadata/1/6eee7ad0-bf75-0131-71fc-0eeabbd7a8b4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIEWLY3MN4YGZQOWA%2F20140516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20140516T221456Z&X-Amz-Expires=180&X-Amz-SignedHeaders=host&partNumber=1&uploadId=xQDI8q.aDdWdWIvSpRGLOFqnPQqJoMGZ88r9g_q7z2gW6U4rNZx8Zb_Wh9m07TDJM1x4rCTM18UCzdXaYjJu.SBH89LAiA4ye698TfMPyam4BO7ifs7HLuiBPrEW.zIz&X-Amz-Signature=69bc7be37c8c42096e78aa4ff752f073ea890481c5f76eac5ad40a5ab9466997',
+            'partsize' => 21,
+            'part_number' => 1,
+            'available_parts' => 10_000,
+            'send' => {
+              'partsize' => 'required-parameter Content-Length',
+              'partdata' => 'body',
+            },
+            'headers' => {},
+            'parameters' => {},
+          }
+        end
+
+        let(:step1_2) do
+          {
+            'ref' => 'put-378670',
+            'path' => 'NewFile.txt',
+            'action' => 'put/write',
+            'ask_about_overwrites' => false,
+            'http_method' => 'PUT',
+            'upload_uri' => 'https://s3.amazonaws.com/objects.brickftp.com/metadata/2/6eee7ad0-bf75-0131-71fc-0eeabbd7a8b4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIEWLY3MN4YGZQOWA%2F20140516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20140516T221456Z&X-Amz-Expires=180&X-Amz-SignedHeaders=host&partNumber=1&uploadId=xQDI8q.aDdWdWIvSpRGLOFqnPQqJoMGZ88r9g_q7z2gW6U4rNZx8Zb_Wh9m07TDJM1x4rCTM18UCzdXaYjJu.SBH89LAiA4ye698TfMPyam4BO7ifs7HLuiBPrEW.zIz&X-Amz-Signature=69bc7be37c8c42096e78aa4ff752f073ea890481c5f76eac5ad40a5ab9466997',
+            'partsize' => 19,
+            'part_number' => 2,
+            'available_parts' => 10_000,
+            'send' => {
+              'partsize' => 'required-parameter Content-Length',
+              'partdata' => 'body',
+            },
+            'headers' => {},
+            'parameters' => {},
+          }
+        end
+
+        let(:step3) do
+          {
+            'id' => 1,
+            'path' => 'NewFile.txt',
+            'type' => 'file',
+            'size' => 412,
+            'mtime' => '2014-05-17T05:14:35+00:00',
+            'crc32' => nil,
+            'md5' => nil,
+          }
+        end
+
+        before do
+          stub_request(:post, 'https://koshigoe.brickftp.com/api/rest/v1/files/NewFile.txt')
+            .with(basic_auth: %w[xxxxxxxx x], body: { action: 'put' }.to_json)
+            .to_return(status: 200, body: step1_1.to_json)
+
+          stub_request(:post, 'https://koshigoe.brickftp.com/api/rest/v1/files/NewFile.txt')
+            .with(basic_auth: %w[xxxxxxxx x], body: { action: 'put', part: 2, ref: 'put-378670' }.to_json)
+            .to_return(status: 200, body: step1_2.to_json)
+
+          stub_request(:put, 'https://s3.amazonaws.com/objects.brickftp.com/metadata/1/6eee7ad0-bf75-0131-71fc-0eeabbd7a8b4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIEWLY3MN4YGZQOWA%2F20140516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20140516T221456Z&X-Amz-Expires=180&X-Amz-SignedHeaders=host&partNumber=1&uploadId=xQDI8q.aDdWdWIvSpRGLOFqnPQqJoMGZ88r9g_q7z2gW6U4rNZx8Zb_Wh9m07TDJM1x4rCTM18UCzdXaYjJu.SBH89LAiA4ye698TfMPyam4BO7ifs7HLuiBPrEW.zIz&X-Amz-Signature=69bc7be37c8c42096e78aa4ff752f073ea890481c5f76eac5ad40a5ab9466997')
+            .with(body: 'This is a test upload')
+            .to_return(status: 200, body: '')
+
+          stub_request(:put, 'https://s3.amazonaws.com/objects.brickftp.com/metadata/2/6eee7ad0-bf75-0131-71fc-0eeabbd7a8b4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIEWLY3MN4YGZQOWA%2F20140516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20140516T221456Z&X-Amz-Expires=180&X-Amz-SignedHeaders=host&partNumber=1&uploadId=xQDI8q.aDdWdWIvSpRGLOFqnPQqJoMGZ88r9g_q7z2gW6U4rNZx8Zb_Wh9m07TDJM1x4rCTM18UCzdXaYjJu.SBH89LAiA4ye698TfMPyam4BO7ifs7HLuiBPrEW.zIz&X-Amz-Signature=69bc7be37c8c42096e78aa4ff752f073ea890481c5f76eac5ad40a5ab9466997')
+            .with(body: " file to BrickFTP.\n")
+            .to_return(status: 200, body: '')
+
+          stub_request(:post, 'https://koshigoe.brickftp.com/api/rest/v1/files/NewFile.txt')
+            .with(basic_auth: %w[xxxxxxxx x], body: { action: 'end', ref: 'put-378670' }.to_json)
+            .to_return(status: 200, body: step3.to_json)
+        end
+
+        it 'return instance of BrickFTP::API::FileOperation::Upload' do
+          is_expected.to be_an_instance_of BrickFTP::API::FileOperation::Upload
+        end
+
+        it 'set attributes' do
+          upload = subject
+          expect(upload.ref).to eq 'put-378670'
+          expect(upload.path).to eq 'NewFile.txt'
+          expect(upload.action).to eq 'put/write'
+          expect(upload.ask_about_overwrites).to eq false
+          expect(upload.http_method).to eq 'PUT'
+          expect(upload.upload_uri).to eq 'https://s3.amazonaws.com/objects.brickftp.com/metadata/2/6eee7ad0-bf75-0131-71fc-0eeabbd7a8b4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIEWLY3MN4YGZQOWA%2F20140516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20140516T221456Z&X-Amz-Expires=180&X-Amz-SignedHeaders=host&partNumber=1&uploadId=xQDI8q.aDdWdWIvSpRGLOFqnPQqJoMGZ88r9g_q7z2gW6U4rNZx8Zb_Wh9m07TDJM1x4rCTM18UCzdXaYjJu.SBH89LAiA4ye698TfMPyam4BO7ifs7HLuiBPrEW.zIz&X-Amz-Signature=69bc7be37c8c42096e78aa4ff752f073ea890481c5f76eac5ad40a5ab9466997'
+          expect(upload.partsize).to eq 19
+          expect(upload.part_number).to eq 2
+          expect(upload.available_parts).to eq 10_000
+          expect(upload.properties['send']).to eq('partsize' => 'required-parameter Content-Length', 'partdata' => 'body')
+          expect(upload.headers).to eq({})
+          expect(upload.parameters).to eq({})
+          expect(upload.id).to eq 1
+          expect(upload.type).to eq 'file'
+          expect(upload.size).to eq 412
+          expect(upload.mtime).to eq '2014-05-17T05:14:35+00:00'
+          expect(upload.crc32).to eq nil
+          expect(upload.md5).to eq nil
+        end
+      end
     end
 
     context 'failure' do
       let(:source) { '' }
+      let(:chunk_size) { nil }
 
       before do
         stub_request(:post, 'https://koshigoe.brickftp.com/api/rest/v1/files/NewFile.txt')

--- a/spec/brick_ftp/api/file_operation/upload_spec.rb
+++ b/spec/brick_ftp/api/file_operation/upload_spec.rb
@@ -9,76 +9,78 @@ RSpec.describe BrickFTP::API::FileOperation::Upload, type: :lib do
     context 'success' do
       let(:source) { open('spec/data/file_upload/source.txt') }
 
-      let(:step1) do
-        {
-          'ref' => 'put-378670',
-          'path' => 'NewFile.txt',
-          'action' => 'put/write',
-          'ask_about_overwrites' => false,
-          'http_method' => 'PUT',
-          'upload_uri' => 'https://s3.amazonaws.com/objects.brickftp.com/metadata/1/6eee7ad0-bf75-0131-71fc-0eeabbd7a8b4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIEWLY3MN4YGZQOWA%2F20140516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20140516T221456Z&X-Amz-Expires=180&X-Amz-SignedHeaders=host&partNumber=1&uploadId=xQDI8q.aDdWdWIvSpRGLOFqnPQqJoMGZ88r9g_q7z2gW6U4rNZx8Zb_Wh9m07TDJM1x4rCTM18UCzdXaYjJu.SBH89LAiA4ye698TfMPyam4BO7ifs7HLuiBPrEW.zIz&X-Amz-Signature=69bc7be37c8c42096e78aa4ff752f073ea890481c5f76eac5ad40a5ab9466997',
-          'partsize' => 5_242_880,
-          'part_number' => 1,
-          'available_parts' => 10_000,
-          'send' => {
-            'partsize' => 'required-parameter Content-Length',
-            'partdata' => 'body',
-          },
-          'headers' => {},
-          'parameters' => {},
-        }
-      end
+      context 'single part upload' do
+        let(:step1) do
+          {
+            'ref' => 'put-378670',
+            'path' => 'NewFile.txt',
+            'action' => 'put/write',
+            'ask_about_overwrites' => false,
+            'http_method' => 'PUT',
+            'upload_uri' => 'https://s3.amazonaws.com/objects.brickftp.com/metadata/1/6eee7ad0-bf75-0131-71fc-0eeabbd7a8b4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIEWLY3MN4YGZQOWA%2F20140516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20140516T221456Z&X-Amz-Expires=180&X-Amz-SignedHeaders=host&partNumber=1&uploadId=xQDI8q.aDdWdWIvSpRGLOFqnPQqJoMGZ88r9g_q7z2gW6U4rNZx8Zb_Wh9m07TDJM1x4rCTM18UCzdXaYjJu.SBH89LAiA4ye698TfMPyam4BO7ifs7HLuiBPrEW.zIz&X-Amz-Signature=69bc7be37c8c42096e78aa4ff752f073ea890481c5f76eac5ad40a5ab9466997',
+            'partsize' => 5_242_880,
+            'part_number' => 1,
+            'available_parts' => 10_000,
+            'send' => {
+              'partsize' => 'required-parameter Content-Length',
+              'partdata' => 'body',
+            },
+            'headers' => {},
+            'parameters' => {},
+          }
+        end
 
-      let(:step3) do
-        {
-          'id' => 1,
-          'path' => 'NewFile.txt',
-          'type' => 'file',
-          'size' => 412,
-          'mtime' => '2014-05-17T05:14:35+00:00',
-          'crc32' => nil,
-          'md5' => nil,
-        }
-      end
+        let(:step3) do
+          {
+            'id' => 1,
+            'path' => 'NewFile.txt',
+            'type' => 'file',
+            'size' => 412,
+            'mtime' => '2014-05-17T05:14:35+00:00',
+            'crc32' => nil,
+            'md5' => nil,
+          }
+        end
 
-      before do
-        stub_request(:post, 'https://koshigoe.brickftp.com/api/rest/v1/files/NewFile.txt')
-          .with(basic_auth: %w[xxxxxxxx x], body: { action: 'put' }.to_json)
-          .to_return(status: 200, body: step1.to_json)
+        before do
+          stub_request(:post, 'https://koshigoe.brickftp.com/api/rest/v1/files/NewFile.txt')
+            .with(basic_auth: %w[xxxxxxxx x], body: { action: 'put' }.to_json)
+            .to_return(status: 200, body: step1.to_json)
 
-        stub_request(:put, 'https://s3.amazonaws.com/objects.brickftp.com/metadata/1/6eee7ad0-bf75-0131-71fc-0eeabbd7a8b4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIEWLY3MN4YGZQOWA%2F20140516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20140516T221456Z&X-Amz-Expires=180&X-Amz-SignedHeaders=host&partNumber=1&uploadId=xQDI8q.aDdWdWIvSpRGLOFqnPQqJoMGZ88r9g_q7z2gW6U4rNZx8Zb_Wh9m07TDJM1x4rCTM18UCzdXaYjJu.SBH89LAiA4ye698TfMPyam4BO7ifs7HLuiBPrEW.zIz&X-Amz-Signature=69bc7be37c8c42096e78aa4ff752f073ea890481c5f76eac5ad40a5ab9466997')
-          .with(body: "This is a test upload file to BrickFTP.\n")
-          .to_return(status: 200, body: '')
+          stub_request(:put, 'https://s3.amazonaws.com/objects.brickftp.com/metadata/1/6eee7ad0-bf75-0131-71fc-0eeabbd7a8b4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIEWLY3MN4YGZQOWA%2F20140516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20140516T221456Z&X-Amz-Expires=180&X-Amz-SignedHeaders=host&partNumber=1&uploadId=xQDI8q.aDdWdWIvSpRGLOFqnPQqJoMGZ88r9g_q7z2gW6U4rNZx8Zb_Wh9m07TDJM1x4rCTM18UCzdXaYjJu.SBH89LAiA4ye698TfMPyam4BO7ifs7HLuiBPrEW.zIz&X-Amz-Signature=69bc7be37c8c42096e78aa4ff752f073ea890481c5f76eac5ad40a5ab9466997')
+            .with(body: "This is a test upload file to BrickFTP.\n")
+            .to_return(status: 200, body: '')
 
-        stub_request(:post, 'https://koshigoe.brickftp.com/api/rest/v1/files/NewFile.txt')
-          .with(basic_auth: %w[xxxxxxxx x], body: { action: 'end', ref: 'put-378670' }.to_json)
-          .to_return(status: 200, body: step3.to_json)
-      end
+          stub_request(:post, 'https://koshigoe.brickftp.com/api/rest/v1/files/NewFile.txt')
+            .with(basic_auth: %w[xxxxxxxx x], body: { action: 'end', ref: 'put-378670' }.to_json)
+            .to_return(status: 200, body: step3.to_json)
+        end
 
-      it 'return instance of BrickFTP::API::FileOperation::Upload' do
-        is_expected.to be_an_instance_of BrickFTP::API::FileOperation::Upload
-      end
+        it 'return instance of BrickFTP::API::FileOperation::Upload' do
+          is_expected.to be_an_instance_of BrickFTP::API::FileOperation::Upload
+        end
 
-      it 'set attributes' do
-        upload = subject
-        expect(upload.ref).to eq 'put-378670'
-        expect(upload.path).to eq 'NewFile.txt'
-        expect(upload.action).to eq 'put/write'
-        expect(upload.ask_about_overwrites).to eq false
-        expect(upload.http_method).to eq 'PUT'
-        expect(upload.upload_uri).to eq 'https://s3.amazonaws.com/objects.brickftp.com/metadata/1/6eee7ad0-bf75-0131-71fc-0eeabbd7a8b4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIEWLY3MN4YGZQOWA%2F20140516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20140516T221456Z&X-Amz-Expires=180&X-Amz-SignedHeaders=host&partNumber=1&uploadId=xQDI8q.aDdWdWIvSpRGLOFqnPQqJoMGZ88r9g_q7z2gW6U4rNZx8Zb_Wh9m07TDJM1x4rCTM18UCzdXaYjJu.SBH89LAiA4ye698TfMPyam4BO7ifs7HLuiBPrEW.zIz&X-Amz-Signature=69bc7be37c8c42096e78aa4ff752f073ea890481c5f76eac5ad40a5ab9466997'
-        expect(upload.partsize).to eq 5_242_880
-        expect(upload.part_number).to eq 1
-        expect(upload.available_parts).to eq 10_000
-        expect(upload.properties['send']).to eq('partsize' => 'required-parameter Content-Length', 'partdata' => 'body')
-        expect(upload.headers).to eq({})
-        expect(upload.parameters).to eq({})
-        expect(upload.id).to eq 1
-        expect(upload.type).to eq 'file'
-        expect(upload.size).to eq 412
-        expect(upload.mtime).to eq '2014-05-17T05:14:35+00:00'
-        expect(upload.crc32).to eq nil
-        expect(upload.md5).to eq nil
+        it 'set attributes' do
+          upload = subject
+          expect(upload.ref).to eq 'put-378670'
+          expect(upload.path).to eq 'NewFile.txt'
+          expect(upload.action).to eq 'put/write'
+          expect(upload.ask_about_overwrites).to eq false
+          expect(upload.http_method).to eq 'PUT'
+          expect(upload.upload_uri).to eq 'https://s3.amazonaws.com/objects.brickftp.com/metadata/1/6eee7ad0-bf75-0131-71fc-0eeabbd7a8b4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIEWLY3MN4YGZQOWA%2F20140516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20140516T221456Z&X-Amz-Expires=180&X-Amz-SignedHeaders=host&partNumber=1&uploadId=xQDI8q.aDdWdWIvSpRGLOFqnPQqJoMGZ88r9g_q7z2gW6U4rNZx8Zb_Wh9m07TDJM1x4rCTM18UCzdXaYjJu.SBH89LAiA4ye698TfMPyam4BO7ifs7HLuiBPrEW.zIz&X-Amz-Signature=69bc7be37c8c42096e78aa4ff752f073ea890481c5f76eac5ad40a5ab9466997'
+          expect(upload.partsize).to eq 5_242_880
+          expect(upload.part_number).to eq 1
+          expect(upload.available_parts).to eq 10_000
+          expect(upload.properties['send']).to eq('partsize' => 'required-parameter Content-Length', 'partdata' => 'body')
+          expect(upload.headers).to eq({})
+          expect(upload.parameters).to eq({})
+          expect(upload.id).to eq 1
+          expect(upload.type).to eq 'file'
+          expect(upload.size).to eq 412
+          expect(upload.mtime).to eq '2014-05-17T05:14:35+00:00'
+          expect(upload.crc32).to eq nil
+          expect(upload.md5).to eq nil
+        end
       end
     end
 

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -491,9 +491,18 @@ RSpec.describe BrickFTP::Client, type: :lib do
     end
 
     describe '#upload_file' do
-      it 'delegate BrickFTP::API::FileOperation::Upload.create' do
-        expect(BrickFTP::API::FileOperation::Upload).to receive(:create).with(path: 'a/b', source: 'b')
-        described_class.new.upload_file(path: 'a/b', source: 'b')
+      context 'without chunk_size option' do
+        it 'delegate BrickFTP::API::FileOperation::Upload.create' do
+          expect(BrickFTP::API::FileOperation::Upload).to receive(:create).with(path: 'a/b', source: 'b', chunk_size: nil)
+          described_class.new.upload_file(path: 'a/b', source: 'b')
+        end
+      end
+
+      context 'with chunk_size option' do
+        it 'delegate BrickFTP::API::FileOperation::Upload.create' do
+          expect(BrickFTP::API::FileOperation::Upload).to receive(:create).with(path: 'a/b', source: 'b', chunk_size: 10)
+          described_class.new.upload_file(path: 'a/b', source: 'b', chunk_size: 10)
+        end
       end
     end
   end

--- a/spec/brick_ftp/utils/chunk_io_spec.rb
+++ b/spec/brick_ftp/utils/chunk_io_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'tempfile'
+
+RSpec.describe BrickFTP::Utils::ChunkIO do
+  describe '#each_chunk' do
+    context 'chunk_size is nil' do
+      it 'chunk has whole data' do
+        Tempfile.create do |io|
+          io.write('DATA')
+          io.rewind
+
+          res = ''
+          called = 0
+          described_class.new(io).each_chunk do |chunk|
+            res << chunk.read
+            called += 1
+          end
+          expect(res).to eq 'DATA'
+          expect(called).to eq 1
+        end
+      end
+    end
+
+    context 'chunk_size is not nil' do
+      it 'split by chunk_size' do
+        Tempfile.create do |io|
+          io.write('DATA')
+          io.rewind
+
+          res = ''
+          called = 0
+          described_class.new(io).each_chunk(chunk_size: 1) do |chunk|
+            res << chunk.read
+            called += 1
+          end
+          expect(res).to eq 'DATA'
+          expect(called).to eq 4
+        end
+      end
+    end
+  end
+end

--- a/spec/brick_ftp/utils/chunk_io_spec.rb
+++ b/spec/brick_ftp/utils/chunk_io_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'tempfile'
 
 RSpec.describe BrickFTP::Utils::ChunkIO do
-  describe '#each_chunk' do
+  describe '#each' do
     context 'chunk_size is nil' do
       it 'chunk has whole data' do
         Tempfile.create do |io|
@@ -11,7 +11,7 @@ RSpec.describe BrickFTP::Utils::ChunkIO do
 
           res = ''
           called = 0
-          described_class.new(io).each_chunk do |chunk|
+          described_class.new(io).each do |chunk|
             res << chunk.read
             called += 1
           end
@@ -29,7 +29,28 @@ RSpec.describe BrickFTP::Utils::ChunkIO do
 
           res = ''
           called = 0
-          described_class.new(io).each_chunk(chunk_size: 1) do |chunk|
+          described_class.new(io, chunk_size: 1).each do |chunk|
+            res << chunk.read
+            called += 1
+          end
+          expect(res).to eq 'DATA'
+          expect(called).to eq 4
+        end
+      end
+    end
+
+    context 'without block' do
+      it 'return Enumerator' do
+        Tempfile.create do |io|
+          io.write('DATA')
+          io.rewind
+
+          enum = described_class.new(io, chunk_size: 1).each
+          expect(enum).to be_an_instance_of(Enumerator)
+
+          res = ''
+          called = 0
+          enum.each do |chunk|
             res << chunk.read
             called += 1
           end


### PR DESCRIPTION
Why
----

The File Uploading API supports multi-part uploading.

- [File Uploading · REST API · Docs · BrickFTP](https://brickftp.com/docs/rest-api/file-uploading/)

But this library has not supported multi-part uploading.

How
----

- Add `chunk_size` option to `BrickFTP::Client#upload_file`.
- `chunk_size` is `nil` -> single part uploading
- `chunk_size` is integer value -> multi part uploading

```
> open('10MB', 'w') { |f| f.write 'a' * 10_000_000 }
> open('10MB') { |f| client.upload_file(path: '/test-koshigoe/chunk-10mb', source: f, chunk_size: 5_242_880) }
```

NOTE
----

### chunk_size

This library has not validate value of `chunk_size` yet.
If value of 1chunk_size` is not between 5MiB and 5GiB, it raise an exception like `BrickFTP::HTTPClient::Error: 424: ...`

> Recommended size of upload. When uploading file pieces, the piece sizes are required to be between 5 MB and 5 GB (except the last part). This value provides a recommended size to upload for this part without adding another part.

- `5 MB` means `5 MiB` (maybe)
- `5 GB` means `5 GiB` (maybe)