### PR TITLE
Re-overwrite `as_json` to avoid to too much loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,35 @@ Changelog
 ====
 
 
-[unreleased](https://github.com/koshigoe/brick_ftp/compare/v0.7.1...master)
+[unreleased](https://github.com/koshigoe/brick_ftp/compare/v0.8.0...master)
 ----
 
-[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v0.7.1...master)
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v0.8.0...master)
 
 ### Enhancements:
 
 ### Fixed Bugs:
 
 ### Breaking Changes:
+
+
+[v0.8.0](https://github.com/koshigoe/brick_ftp/compare/v0.7.1...v0.8.0)
+----
+
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v0.7.1...v0.8.0)
+
+### Enhancements:
+
+### Fixed Bugs:
+
+- [#92](https://github.com/koshigoe/brick_ftp/pull/92) Re-Overwrite `as_json` to avoid to too much loop.
+    - fixes [#91](https://github.com/koshigoe/brick_ftp/issues/91)
+
+### Breaking Changes:
+
+- [#92](https://github.com/koshigoe/brick_ftp/pull/92)
+    - Change type of key of returned Hash object from `BrickFTP::API::Base#as_json` to `String`.
+    - Initialize `BrickFTP::API::Base#properties` with all defined attributes.
 
 
 [v0.7.1](https://github.com/koshigoe/brick_ftp/compare/v0.7.0...v0.7.1)

--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -73,7 +73,7 @@ module BrickFTP
       end
 
       def as_json
-        self.class.attributes.each_with_object({}) { |name, res| res[name] = read_property(name) }
+        properties.dup
       end
 
       def to_json

--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -43,7 +43,7 @@ module BrickFTP
       attr_reader :properties
 
       def initialize(params = {})
-        @properties = {}
+        initialize_properties
         params.each { |k, v| write_property(k, v) }
       end
 
@@ -93,6 +93,11 @@ module BrickFTP
       end
 
       private
+
+      def initialize_properties
+        @properties = {}
+        self.class.attributes.each { |key| write_property(key, nil) }
+      end
 
       def respond_to_missing?(method_name, _include_private)
         self.class.attributes.include?(method_name.to_sym)

--- a/lib/brick_ftp/api/file_operation/uploading_session.rb
+++ b/lib/brick_ftp/api/file_operation/uploading_session.rb
@@ -79,6 +79,16 @@ module BrickFTP
         def commit
           UploadingResult.create(path: path, ref: ref)
         end
+
+        # Return single uploading session object.
+        #
+        # NOTE: The `#as_json` method will be overwritten by active_supprt.
+        #
+        # @return [Hash] a JSON serializable object
+        #
+        def as_json
+          properties.dup
+        end
       end
     end
   end

--- a/lib/brick_ftp/version.rb
+++ b/lib/brick_ftp/version.rb
@@ -1,3 +1,3 @@
 module BrickFTP
-  VERSION = '0.7.1'.freeze
+  VERSION = '0.8.0'.freeze
 end

--- a/spec/brick_ftp/api/base_spec.rb
+++ b/spec/brick_ftp/api/base_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe BrickFTP::API::Base do
   describe '#as_json' do
     subject { api.new(id: '1', value: 'v').as_json }
 
-    it { is_expected.to eq(id: '1', value: 'v', send: nil) }
+    it { is_expected.to eq('id' => '1', 'value' => 'v', 'send' => nil) }
   end
 
   describe '#to_json' do


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/koshigoe/brick_ftp#contributing
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixes #91

<!--
Briefly describe the feature if no issue exists for this PR
-->

If `active_support/core_ext/object/json.rb` loaded, it overwrite `Enumerable#as_json`.

https://github.com/rails/rails/blob/1c383df324fdf0b68b3f54a649eb7d2a4f55bcb7/activesupport/lib/active_support/core_ext/object/json.rb#L132-L136

The `BrickFTP::API::FileOperation::UploadingSession` includes `Enumerable`.
When `BrickFTP::API::FileOperation::UploadingSession#as_json` is called, it call `BrickFTP::API::FileOperation::UploadingSession#to_a`.
The `BrickFTP::API::FileOperation::UploadingSession#each` will iterate `available_parts` times.


## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

- overwrite `BrickFTP::API::FileOperation::UploadingSession#as_json`
    - NOTE: return only single part

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Add activesupport gem to reproduce problem.

```
$ git diff brick_ftp.gemspec
diff --git a/brick_ftp.gemspec b/brick_ftp.gemspec
index 7d1d5ea..d45c890 100644
--- a/brick_ftp.gemspec
+++ b/brick_ftp.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.15'
   spec.add_development_dependency 'webmock', '~> 2.1'
   spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'activesupport'
 
   spec.add_dependency 'deep_hash_transform', '~> 1.0'
   spec.add_dependency 'inifile', '~> 3.0.0'

$ bundle install
```

Call `#as_json` after `require 'active_support/json'`.

```
$ bin/console
> require 'active_support/json'
> BrickFTP::API::FileOperation::UploadingSession.create(path: '/test-koshigoe/multi-part-uploaded.txt').as_json
=> "...."
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
