### PR TITLE
Fix method signature of `#{as,to}_json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,26 @@ Changelog
 ====
 
 
-[unreleased](https://github.com/koshigoe/brick_ftp/compare/v0.8.0...master)
+[unreleased](https://github.com/koshigoe/brick_ftp/compare/v0.8.1...master)
 ----
 
-[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v0.8.0...master)
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v0.8.1...master)
 
 ### Enhancements:
+
+### Fixed Bugs:
+
+### Breaking Changes:
+
+
+[v0.8.1](https://github.com/koshigoe/brick_ftp/compare/v0.8.0...v0.8.1)
+----
+
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v0.8.0...v0.8.1)
+
+### Enhancements:
+
+- [#94](https://github.com/koshigoe/brick_ftp/pull/94) Fix method signature of `#to_json` and `#as_json`
 
 ### Fixed Bugs:
 

--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -72,7 +72,7 @@ module BrickFTP
         true
       end
 
-      def as_json
+      def as_json(*_args)
         properties.dup
       end
 

--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -76,8 +76,8 @@ module BrickFTP
         properties.dup
       end
 
-      def to_json
-        as_json.to_json
+      def to_json(*args)
+        as_json.to_json(*args)
       end
 
       def write_property(key, value)

--- a/lib/brick_ftp/api/file_operation/uploading_session.rb
+++ b/lib/brick_ftp/api/file_operation/uploading_session.rb
@@ -86,7 +86,7 @@ module BrickFTP
         #
         # @return [Hash] a JSON serializable object
         #
-        def as_json
+        def as_json(*_args)
           properties.dup
         end
       end

--- a/lib/brick_ftp/version.rb
+++ b/lib/brick_ftp/version.rb
@@ -1,3 +1,3 @@
 module BrickFTP
-  VERSION = '0.8.0'.freeze
+  VERSION = '0.8.1'.freeze
 end


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/koshigoe/brick_ftp#contributing
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

The `#as_json` and `#to_json` method should accept any arguments.

```ruby
    def as_json(*)
      { JSON.create_id => self.class.name }.merge to_hash
    end

    def to_json(*a)
      as_json.to_json(*a)
    end
```

https://github.com/ruby/ruby/blob/c08f7b80889b531865e74bc5f573df8fa27f2088/ext/json/lib/json/generic_object.rb#L63-L69


## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

- [x] Add unuse arguments to `#as_json`
- [x] Add arguments to `#to_json`

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

- [x] Passing CI

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
