### PR TITLE
Dropping support ruby 2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,6 @@ jobs:
       - store_artifacts:
           path: coverage
           destination: coverage
-  ruby-2.2:
-    <<: *build
-    docker:
-      - image: circleci/ruby:2.2
   ruby-2.3:
     <<: *build
     docker:
@@ -42,7 +38,6 @@ workflows:
   version: 2
   build-using-multi-rubies:
     jobs:
-      - ruby-2.2
       - ruby-2.3
       - ruby-2.4
       - ruby-2.5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Style/EmptyCaseCondition:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Changelog
 
 ### Breaking Changes:
 
+- [Dropping support for Ruby 2.2](https://github.com/koshigoe/brick_ftp/pull/104)
+    - Set `frozen_string_literal: true`
+
 
 [0.8.2](https://github.com/koshigoe/brick_ftp/compare/v0.8.1...v0.8.2)
 ----

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in brick_ftp.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'brick_ftp'

--- a/brick_ftp.gemspec
+++ b/brick_ftp.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.2.0'
+  spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'codecov', '~> 0.1.10'

--- a/brick_ftp.gemspec
+++ b/brick_ftp.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'brick_ftp/version'

--- a/exe/brick_ftp
+++ b/exe/brick_ftp
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 root = File.dirname(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(root, 'lib'))

--- a/lib/brick_ftp.rb
+++ b/lib/brick_ftp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'deep_hash_transform'
 require 'thor'
 require 'brick_ftp/version'

--- a/lib/brick_ftp/api.rb
+++ b/lib/brick_ftp/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class Error < StandardError

--- a/lib/brick_ftp/api/authentication.rb
+++ b/lib/brick_ftp/api/authentication.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
 module BrickFTP
   module API
     module Authentication
-      COOKIE_NAME = 'BrickAPI'.freeze
+      COOKIE_NAME = 'BrickAPI'
 
       # Generate authentication cookie.
       # @param session [BrickFTP::API::Authentication::Session] authentication session object.

--- a/lib/brick_ftp/api/authentication/session.rb
+++ b/lib/brick_ftp/api/authentication/session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module Authentication

--- a/lib/brick_ftp/api/base.rb
+++ b/lib/brick_ftp/api/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
 module BrickFTP

--- a/lib/brick_ftp/api/behavior.rb
+++ b/lib/brick_ftp/api/behavior.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class Behavior < Base

--- a/lib/brick_ftp/api/bundle.rb
+++ b/lib/brick_ftp/api/bundle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class Bundle < Base

--- a/lib/brick_ftp/api/bundle_content.rb
+++ b/lib/brick_ftp/api/bundle_content.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class BundleContent < Base

--- a/lib/brick_ftp/api/bundle_download.rb
+++ b/lib/brick_ftp/api/bundle_download.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class BundleDownload < Base

--- a/lib/brick_ftp/api/file.rb
+++ b/lib/brick_ftp/api/file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class File < Base

--- a/lib/brick_ftp/api/file_operation.rb
+++ b/lib/brick_ftp/api/file_operation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module FileOperation

--- a/lib/brick_ftp/api/file_operation/copy.rb
+++ b/lib/brick_ftp/api/file_operation/copy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module FileOperation

--- a/lib/brick_ftp/api/file_operation/move.rb
+++ b/lib/brick_ftp/api/file_operation/move.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module FileOperation

--- a/lib/brick_ftp/api/file_operation/upload.rb
+++ b/lib/brick_ftp/api/file_operation/upload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module FileOperation

--- a/lib/brick_ftp/api/file_operation/uploading_result.rb
+++ b/lib/brick_ftp/api/file_operation/uploading_result.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module FileOperation

--- a/lib/brick_ftp/api/file_operation/uploading_session.rb
+++ b/lib/brick_ftp/api/file_operation/uploading_session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module FileOperation

--- a/lib/brick_ftp/api/folder.rb
+++ b/lib/brick_ftp/api/folder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class Folder < Base

--- a/lib/brick_ftp/api/folder_behavior.rb
+++ b/lib/brick_ftp/api/folder_behavior.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class FolderBehavior < Base

--- a/lib/brick_ftp/api/group.rb
+++ b/lib/brick_ftp/api/group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class Group < Base

--- a/lib/brick_ftp/api/history.rb
+++ b/lib/brick_ftp/api/history.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module History

--- a/lib/brick_ftp/api/history/file.rb
+++ b/lib/brick_ftp/api/history/file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module History

--- a/lib/brick_ftp/api/history/folder.rb
+++ b/lib/brick_ftp/api/history/folder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module History

--- a/lib/brick_ftp/api/history/login.rb
+++ b/lib/brick_ftp/api/history/login.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module History

--- a/lib/brick_ftp/api/history/site.rb
+++ b/lib/brick_ftp/api/history/site.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module History

--- a/lib/brick_ftp/api/history/user.rb
+++ b/lib/brick_ftp/api/history/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     module History

--- a/lib/brick_ftp/api/notification.rb
+++ b/lib/brick_ftp/api/notification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class Notification < Base

--- a/lib/brick_ftp/api/permission.rb
+++ b/lib/brick_ftp/api/permission.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class Permission < Base

--- a/lib/brick_ftp/api/public_key.rb
+++ b/lib/brick_ftp/api/public_key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class PublicKey < Base

--- a/lib/brick_ftp/api/site_usage.rb
+++ b/lib/brick_ftp/api/site_usage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class SiteUsage < Base

--- a/lib/brick_ftp/api/user.rb
+++ b/lib/brick_ftp/api/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module API
     class User < Base

--- a/lib/brick_ftp/api_component.rb
+++ b/lib/brick_ftp/api_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'erb'
 
 module BrickFTP

--- a/lib/brick_ftp/api_definition.rb
+++ b/lib/brick_ftp/api_definition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module APIDefinition
     def self.included(klass)

--- a/lib/brick_ftp/cli.rb
+++ b/lib/brick_ftp/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module CLI
     def self.start(argv)

--- a/lib/brick_ftp/cli/config.rb
+++ b/lib/brick_ftp/cli/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module CLI
     class Config < Thor

--- a/lib/brick_ftp/cli/main.rb
+++ b/lib/brick_ftp/cli/main.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module CLI
     class Main < Thor

--- a/lib/brick_ftp/cli/site.rb
+++ b/lib/brick_ftp/cli/site.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module CLI
     class Site < Thor

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   class Client
     # Login and store authentication session.

--- a/lib/brick_ftp/configuration.rb
+++ b/lib/brick_ftp/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 require 'inifile'
 
@@ -37,7 +39,7 @@ module BrickFTP
     DEFAULT_OPEN_TIMEOUT = 10
     DEFAULT_READ_TIMEOUT = 30
 
-    DEFAULT_PROFILE = 'global'.freeze
+    DEFAULT_PROFILE = 'global'
     # Name of storable configurations. (TODO: log_path, log_level, log_formatter)
     STORABLE_CONFIGURATION_KEYS = %w[subdomain api_key open_timeout read_timeout].freeze
 

--- a/lib/brick_ftp/http_client.rb
+++ b/lib/brick_ftp/http_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/https'
 require 'json'
 require 'cgi'
@@ -25,7 +27,7 @@ module BrickFTP
       end
     end
 
-    USER_AGENT = 'BrickFTP Client/0.1 (https://github.com/koshigoe/brick_ftp)'.freeze
+    USER_AGENT = 'BrickFTP Client/0.1 (https://github.com/koshigoe/brick_ftp)'
 
     def initialize(host = nil)
       @host = host || BrickFTP.config.api_host

--- a/lib/brick_ftp/log_formatter.rb
+++ b/lib/brick_ftp/log_formatter.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module BrickFTP
   class LogFormatter < Logger::Formatter
-    FORMAT = "severity:%{severity}\tpid:%{pid}\ttime:%{time}\tmessage:%{message}\n".freeze
+    FORMAT = "severity:%{severity}\tpid:%{pid}\ttime:%{time}\tmessage:%{message}\n"
 
     def call(severity, time, _program_name, message)
       params = {

--- a/lib/brick_ftp/utils.rb
+++ b/lib/brick_ftp/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module Utils
   end

--- a/lib/brick_ftp/utils/chunk_io.rb
+++ b/lib/brick_ftp/utils/chunk_io.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 
 module BrickFTP

--- a/lib/brick_ftp/version.rb
+++ b/lib/brick_ftp/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
-  VERSION = '0.8.2'.freeze
+  VERSION = '0.8.2'
 end

--- a/lib/brick_ftp/webhook.rb
+++ b/lib/brick_ftp/webhook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrickFTP
   module Webhook
   end

--- a/lib/brick_ftp/webhook/request.rb
+++ b/lib/brick_ftp/webhook/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
 module BrickFTP

--- a/spec/brick_ftp/api/authentication/session_spec.rb
+++ b/spec/brick_ftp/api/authentication/session_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::Authentication::Session, type: :lib do

--- a/spec/brick_ftp/api/authentication_spec.rb
+++ b/spec/brick_ftp/api/authentication_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::Authentication, type: :lib do

--- a/spec/brick_ftp/api/base_spec.rb
+++ b/spec/brick_ftp/api/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::Base do

--- a/spec/brick_ftp/api/behavior_folder_spec.rb
+++ b/spec/brick_ftp/api/behavior_folder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::FolderBehavior, type: :lib do

--- a/spec/brick_ftp/api/behavior_spec.rb
+++ b/spec/brick_ftp/api/behavior_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::Behavior, type: :lib do

--- a/spec/brick_ftp/api/bundle_content_spec.rb
+++ b/spec/brick_ftp/api/bundle_content_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::BundleContent, type: :lib do

--- a/spec/brick_ftp/api/bundle_download_spec.rb
+++ b/spec/brick_ftp/api/bundle_download_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::BundleDownload, type: :lib do

--- a/spec/brick_ftp/api/bundle_spec.rb
+++ b/spec/brick_ftp/api/bundle_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::Bundle, type: :lib do

--- a/spec/brick_ftp/api/file_operation/copy_spec.rb
+++ b/spec/brick_ftp/api/file_operation/copy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::FileOperation::Copy, type: :lib do

--- a/spec/brick_ftp/api/file_operation/move_spec.rb
+++ b/spec/brick_ftp/api/file_operation/move_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::FileOperation::Move, type: :lib do

--- a/spec/brick_ftp/api/file_operation/upload_spec.rb
+++ b/spec/brick_ftp/api/file_operation/upload_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::FileOperation::Upload, type: :lib do

--- a/spec/brick_ftp/api/file_operation/uploading_result_spec.rb
+++ b/spec/brick_ftp/api/file_operation/uploading_result_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::FileOperation::UploadingResult, type: :lib do

--- a/spec/brick_ftp/api/file_operation/uploading_session_spec.rb
+++ b/spec/brick_ftp/api/file_operation/uploading_session_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::FileOperation::UploadingSession, type: :lib do

--- a/spec/brick_ftp/api/file_spec.rb
+++ b/spec/brick_ftp/api/file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::File, type: :lib do

--- a/spec/brick_ftp/api/folder_spec.rb
+++ b/spec/brick_ftp/api/folder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::Folder, type: :lib do

--- a/spec/brick_ftp/api/group_spec.rb
+++ b/spec/brick_ftp/api/group_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::Group, type: :lib do

--- a/spec/brick_ftp/api/history/file_spec.rb
+++ b/spec/brick_ftp/api/history/file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::History::File, type: :lib do

--- a/spec/brick_ftp/api/history/folder_spec.rb
+++ b/spec/brick_ftp/api/history/folder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::History::Folder, type: :lib do

--- a/spec/brick_ftp/api/history/login_spec.rb
+++ b/spec/brick_ftp/api/history/login_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::History::Login, type: :lib do

--- a/spec/brick_ftp/api/history/site_spec.rb
+++ b/spec/brick_ftp/api/history/site_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::History::Site, type: :lib do

--- a/spec/brick_ftp/api/history/user_spec.rb
+++ b/spec/brick_ftp/api/history/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::History::User, type: :lib do

--- a/spec/brick_ftp/api/notification_spec.rb
+++ b/spec/brick_ftp/api/notification_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::Notification, type: :lib do

--- a/spec/brick_ftp/api/permission_spec.rb
+++ b/spec/brick_ftp/api/permission_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::Permission, type: :lib do

--- a/spec/brick_ftp/api/public_key_spec.rb
+++ b/spec/brick_ftp/api/public_key_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::PublicKey, type: :lib do

--- a/spec/brick_ftp/api/site_usage_spec.rb
+++ b/spec/brick_ftp/api/site_usage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::SiteUsage, type: :lib do

--- a/spec/brick_ftp/api/user_spec.rb
+++ b/spec/brick_ftp/api/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::API::User, type: :lib do

--- a/spec/brick_ftp/api_component_spec.rb
+++ b/spec/brick_ftp/api_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::APIComponent, type: :lib do

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::Client, type: :lib do

--- a/spec/brick_ftp/configuration_spec.rb
+++ b/spec/brick_ftp/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::Configuration, type: :lib do

--- a/spec/brick_ftp/http_client_spec.rb
+++ b/spec/brick_ftp/http_client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::HTTPClient, type: :lib do

--- a/spec/brick_ftp/utils/chunk_io_spec.rb
+++ b/spec/brick_ftp/utils/chunk_io_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tempfile'
 

--- a/spec/brick_ftp/utils/chunk_io_spec.rb
+++ b/spec/brick_ftp/utils/chunk_io_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BrickFTP::Utils::ChunkIO do
           io.write('DATA')
           io.rewind
 
-          res = ''
+          res = +''
           called = 0
           described_class.new(io).each do |chunk|
             res << chunk.read
@@ -29,7 +29,7 @@ RSpec.describe BrickFTP::Utils::ChunkIO do
           io.write('DATA')
           io.rewind
 
-          res = ''
+          res = +''
           called = 0
           described_class.new(io, chunk_size: 1).each do |chunk|
             res << chunk.read
@@ -50,7 +50,7 @@ RSpec.describe BrickFTP::Utils::ChunkIO do
           enum = described_class.new(io, chunk_size: 1).each
           expect(enum).to be_an_instance_of(Enumerator)
 
-          res = ''
+          res = +''
           called = 0
           enum.each do |chunk|
             res << chunk.read

--- a/spec/brick_ftp/webhook/request_spec.rb
+++ b/spec/brick_ftp/webhook/request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe BrickFTP::Webhook::Request, type: :lib do

--- a/spec/brick_ftp_spec.rb
+++ b/spec/brick_ftp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe BrickFTP do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'simplecov'
 SimpleCov.start do


### PR DESCRIPTION
## What did you implement:

Closes #103

## How did you implement it:

- [x] update gemspec
- [x] update rubocop config
    - Append `# frozen_string_literal: true`
- [x] update .circleco/config.yml
- [x] update CHANGELOG.md

## How can we verify it:

pass CI

## Todos:

- [x] ~Write tests~
- [x] Write documentation
- [x] ~Fix linting errors~
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
