### PR TITLE
Allow to upload file using StringIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@ Changelog
 ====
 
 
-[unreleased](https://github.com/koshigoe/brick_ftp/compare/v1.0.0.beta3...master)
+[unreleased](https://github.com/koshigoe/brick_ftp/compare/v1.0.0.beta4...master)
 ----
 
-[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v1.0.0.beta3...master)
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v1.0.0.beta4...master)
 
 ### Enhancements:
 
@@ -14,10 +14,10 @@ Changelog
 ### Breaking Changes:
 
 
-[v1.0.0.beta](https://github.com/koshigoe/brick_ftp/compare/v0.8.2...v1.0.0.beta3)
+[v1.0.0.beta](https://github.com/koshigoe/brick_ftp/compare/v0.8.2...v1.0.0.beta4)
 ----
 
-[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v0.8.2...v1.0.0.beta3)
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v0.8.2...v1.0.0.beta4)
 
 ### Enhancements:
 
@@ -38,6 +38,8 @@ Changelog
         - Remove Configuration
         - Remove unnecessary dependencies
         - etc.
+- [#111](https://github.com/koshigoe/brick_ftp/pull/111) Allow to upload file using `StringIO`
+    - ignore `chunk_size:` option if `io` is a `StringIO`
 
 [0.8.2](https://github.com/koshigoe/brick_ftp/compare/v0.8.1...v0.8.2)
 ----

--- a/lib/brick_ftp/restful_api/upload_file.rb
+++ b/lib/brick_ftp/restful_api/upload_file.rb
@@ -30,7 +30,8 @@ module BrickFTP
       #
       # @param [String] path Full path of the file or folder. Maximum of 550 characters.
       # @param [IO] data
-      # @param [Integer, nil] chunk_size the chunk sizes are required to be between 5 MB and 5 GB
+      # @param [Integer, nil] chunk_size the chunk sizes are required to be between 5 MB and 5 GB.
+      #   This option is ignored if `data` is `StringIO`.
       # @return [BrickFTP::Types::File] File object
       #
       def call(path, data, chunk_size: nil)

--- a/lib/brick_ftp/utils/chunk_io.rb
+++ b/lib/brick_ftp/utils/chunk_io.rb
@@ -11,7 +11,9 @@ module BrickFTP
 
       # Wrap IO object.
       #
-      # @param [IO] io an IO object.
+      # NOTE: If `io` is a `StringIO`, it does not split data even if `chunk_size:` option is specified.
+      #
+      # @param [IO, StringIO] io an IO object.
       # @param [Integer] chunk_size Size of chunk.
       #
       def initialize(io, chunk_size: nil)
@@ -27,7 +29,7 @@ module BrickFTP
       def each(&block)
         return enum_for(__method__) unless block
 
-        if chunk_size
+        if chunk_size && io.is_a?(IO)
           each_chunk(&block)
         else
           whole(&block)

--- a/lib/brick_ftp/utils/chunk_io.rb
+++ b/lib/brick_ftp/utils/chunk_io.rb
@@ -11,10 +11,9 @@ module BrickFTP
 
       # Wrap IO object.
       #
-      # NOTE: If `io` is a `StringIO`, it does not split data even if `chunk_size:` option is specified.
-      #
       # @param [IO, StringIO] io an IO object.
       # @param [Integer] chunk_size Size of chunk.
+      #   This option is ignored if `io` is `StringIO`.
       #
       def initialize(io, chunk_size: nil)
         @io = io

--- a/spec/brick_ftp/restful_api/upload_file_spec.rb
+++ b/spec/brick_ftp/restful_api/upload_file_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'stringio'
 
 RSpec.describe BrickFTP::RESTfulAPI::UploadFile, type: :lib do
   describe '#call' do
@@ -59,79 +60,137 @@ RSpec.describe BrickFTP::RESTfulAPI::UploadFile, type: :lib do
     end
 
     context 'chunk_size: 5_242_880' do
-      it 'multi upload' do
-        expected_upload = BrickFTP::Types::Upload.new(
-          ref: 'put-378670',
-          http_method: 'PUT',
-          upload_uri: 'https://s3.amazonaws.com/objects.brickftp.com/',
-          part_number: 1
-        )
-
-        stub_request(:post, 'https://subdomain.brickftp.com/api/rest/v1/files/path')
-          .with(
-            basic_auth: %w[api-key x],
-            headers: {
-              'User-Agent' => 'BrickFTP Client/1.0 (https://github.com/koshigoe/brick_ftp)',
-            },
-            body: { action: 'put' }.to_json
+      context 'File' do
+        it 'multi upload' do
+          expected_upload = BrickFTP::Types::Upload.new(
+            ref: 'put-378670',
+            http_method: 'PUT',
+            upload_uri: 'https://s3.amazonaws.com/objects.brickftp.com/',
+            part_number: 1
           )
-          .to_return(body: expected_upload.to_h.to_json)
 
-        stub_request(:put, 'https://s3.amazonaws.com/objects.brickftp.com/')
-          .with(body: 'a' * 5_242_880)
-          .to_return(body: '', status: 200)
+          stub_request(:post, 'https://subdomain.brickftp.com/api/rest/v1/files/path')
+            .with(
+              basic_auth: %w[api-key x],
+              headers: {
+                'User-Agent' => 'BrickFTP Client/1.0 (https://github.com/koshigoe/brick_ftp)',
+              },
+              body: { action: 'put' }.to_json
+            )
+            .to_return(body: expected_upload.to_h.to_json)
 
-        expected_upload2 = BrickFTP::Types::Upload.new(
-          ref: 'put-378670',
-          http_method: 'PUT',
-          upload_uri: 'https://s3.amazonaws.com/objects.brickftp.com/2',
-          part_number: 2
-        )
+          stub_request(:put, 'https://s3.amazonaws.com/objects.brickftp.com/')
+            .with(body: 'a' * 5_242_880)
+            .to_return(body: '', status: 200)
 
-        stub_request(:post, 'https://subdomain.brickftp.com/api/rest/v1/files/path')
-          .with(
-            basic_auth: %w[api-key x],
-            headers: {
-              'User-Agent' => 'BrickFTP Client/1.0 (https://github.com/koshigoe/brick_ftp)',
-            },
-            body: { ref: 'put-378670', part: 2, action: 'put' }.to_json
+          expected_upload2 = BrickFTP::Types::Upload.new(
+            ref: 'put-378670',
+            http_method: 'PUT',
+            upload_uri: 'https://s3.amazonaws.com/objects.brickftp.com/2',
+            part_number: 2
           )
-          .to_return(body: expected_upload2.to_h.to_json)
 
-        stub_request(:put, 'https://s3.amazonaws.com/objects.brickftp.com/2')
-          .with(body: 'b')
-          .to_return(body: '', status: 200)
+          stub_request(:post, 'https://subdomain.brickftp.com/api/rest/v1/files/path')
+            .with(
+              basic_auth: %w[api-key x],
+              headers: {
+                'User-Agent' => 'BrickFTP Client/1.0 (https://github.com/koshigoe/brick_ftp)',
+              },
+              body: { ref: 'put-378670', part: 2, action: 'put' }.to_json
+            )
+            .to_return(body: expected_upload2.to_h.to_json)
 
-        expected_file = BrickFTP::Types::File.new(
-          id: 1_020_304_050,
-          path: 'path',
-          display_name: 'path',
-          type: 'file',
-          size: 412,
-          mtime: '2014-05-17T05:14:35+00:00',
-          provided_mtime: nil,
-          crc32: nil,
-          md5: nil,
-          region: 'us-east-1',
-          permissions: 'rwd'
-        )
+          stub_request(:put, 'https://s3.amazonaws.com/objects.brickftp.com/2')
+            .with(body: 'b')
+            .to_return(body: '', status: 200)
 
-        stub_request(:post, 'https://subdomain.brickftp.com/api/rest/v1/files/path')
-          .with(
-            basic_auth: %w[api-key x],
-            headers: {
-              'User-Agent' => 'BrickFTP Client/1.0 (https://github.com/koshigoe/brick_ftp)',
-            },
-            body: { ref: 'put-378670', action: 'end' }.to_json
+          expected_file = BrickFTP::Types::File.new(
+            id: 1_020_304_050,
+            path: 'path',
+            display_name: 'path',
+            type: 'file',
+            size: 412,
+            mtime: '2014-05-17T05:14:35+00:00',
+            provided_mtime: nil,
+            crc32: nil,
+            md5: nil,
+            region: 'us-east-1',
+            permissions: 'rwd'
           )
-          .to_return(body: expected_file.to_h.to_json)
 
-        client = BrickFTP::RESTfulAPI::Client.new('subdomain', 'api-key')
-        command = BrickFTP::RESTfulAPI::UploadFile.new(client)
+          stub_request(:post, 'https://subdomain.brickftp.com/api/rest/v1/files/path')
+            .with(
+              basic_auth: %w[api-key x],
+              headers: {
+                'User-Agent' => 'BrickFTP Client/1.0 (https://github.com/koshigoe/brick_ftp)',
+              },
+              body: { ref: 'put-378670', action: 'end' }.to_json
+            )
+            .to_return(body: expected_file.to_h.to_json)
 
-        Tempfile.create('base') do |io|
-          io.write('a' * 5_242_880 + 'b')
-          io.flush
+          client = BrickFTP::RESTfulAPI::Client.new('subdomain', 'api-key')
+          command = BrickFTP::RESTfulAPI::UploadFile.new(client)
+
+          Tempfile.create('base') do |io|
+            io.write('a' * 5_242_880 + 'b')
+            io.flush
+            io.rewind
+            expect(command.call('path', io, chunk_size: 5_242_880)).to eq expected_file
+          end
+        end
+      end
+
+      context 'StringIO' do
+        it 'single upload' do
+          expected_upload = BrickFTP::Types::Upload.new(
+            ref: 'put-378670',
+            http_method: 'PUT',
+            upload_uri: 'https://s3.amazonaws.com/objects.brickftp.com/',
+            part_number: 1
+          )
+
+          stub_request(:post, 'https://subdomain.brickftp.com/api/rest/v1/files/path')
+            .with(
+              basic_auth: %w[api-key x],
+              headers: {
+                'User-Agent' => 'BrickFTP Client/1.0 (https://github.com/koshigoe/brick_ftp)',
+              },
+              body: { action: 'put' }.to_json
+            )
+            .to_return(body: expected_upload.to_h.to_json)
+
+          stub_request(:put, 'https://s3.amazonaws.com/objects.brickftp.com/')
+            .with(body: 'a' * 5_242_880 + 'b')
+            .to_return(body: '', status: 200)
+
+          expected_file = BrickFTP::Types::File.new(
+            id: 1_020_304_050,
+            path: 'path',
+            display_name: 'path',
+            type: 'file',
+            size: 412,
+            mtime: '2014-05-17T05:14:35+00:00',
+            provided_mtime: nil,
+            crc32: nil,
+            md5: nil,
+            region: 'us-east-1',
+            permissions: 'rwd'
+          )
+
+          stub_request(:post, 'https://subdomain.brickftp.com/api/rest/v1/files/path')
+            .with(
+              basic_auth: %w[api-key x],
+              headers: {
+                'User-Agent' => 'BrickFTP Client/1.0 (https://github.com/koshigoe/brick_ftp)',
+              },
+              body: { ref: 'put-378670', action: 'end' }.to_json
+            )
+            .to_return(body: expected_file.to_h.to_json)
+
+          client = BrickFTP::RESTfulAPI::Client.new('subdomain', 'api-key')
+          command = BrickFTP::RESTfulAPI::UploadFile.new(client)
+
+          io = StringIO.new('a' * 5_242_880 + 'b')
           io.rewind
           expect(command.call('path', io, chunk_size: 5_242_880)).to eq expected_file
         end

--- a/spec/brick_ftp/utils/chunk_io_spec.rb
+++ b/spec/brick_ftp/utils/chunk_io_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe BrickFTP::Utils::ChunkIO do
     end
 
     context 'chunk_size is not nil' do
+      context 'data is a StringIO' do
+        it 'chunk has whole data' do
+          io = StringIO.new('DATA')
+          io.rewind
+
+          res = +''
+          called = 0
+          described_class.new(io, chunk_size: 1).each do |chunk|
+            res << chunk.read
+            called += 1
+          end
+          expect(res).to eq 'DATA'
+          expect(called).to eq 1
+        end
+      end
+
       context 'data is not a StringIO' do
         it 'split by chunk_size' do
           Tempfile.create('spec') do |io|

--- a/spec/brick_ftp/utils/chunk_io_spec.rb
+++ b/spec/brick_ftp/utils/chunk_io_spec.rb
@@ -24,19 +24,21 @@ RSpec.describe BrickFTP::Utils::ChunkIO do
     end
 
     context 'chunk_size is not nil' do
-      it 'split by chunk_size' do
-        Tempfile.create('spec') do |io|
-          io.write('DATA')
-          io.rewind
+      context 'data is not a StringIO' do
+        it 'split by chunk_size' do
+          Tempfile.create('spec') do |io|
+            io.write('DATA')
+            io.rewind
 
-          res = +''
-          called = 0
-          described_class.new(io, chunk_size: 1).each do |chunk|
-            res << chunk.read
-            called += 1
+            res = +''
+            called = 0
+            described_class.new(io, chunk_size: 1).each do |chunk|
+              res << chunk.read
+              called += 1
+            end
+            expect(res).to eq 'DATA'
+            expect(called).to eq 4
           end
-          expect(res).to eq 'DATA'
-          expect(called).to eq 4
         end
       end
     end


### PR DESCRIPTION
## What did you implement:

Allow to upload file using `StringIO`.

## How did you implement it:

Fix `BrickFTP::Utils::ChunkIO.new` to accept `StringIO` with `chunk_size:` option.

## How can we verify it:

```
$ bin/console
> client = BrickFTP::RESTfulAPI::Client.new(
    ENV['TEST_BRICK_FTP_SUBDOMAIN'],
    ENV['TEST_BRICK_FTP_API_KEY']
  )
> func = BrickFTP::RESTfulAPI::UploadFile.new(client)
> io = StringIO.new('a' * 5_242_880 + 'b')
> func.call('test-koshigoe/pr_111.txt', io, chunk_size: 5_242_880)
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
