### PR TITLE
[Backport 0.8] Allow to upload file using stringio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,20 @@ Changelog
 ====
 
 
-[unreleased](https://github.com/koshigoe/brick_ftp/compare/v0.8.2...master)
+[0.8.3](https://github.com/koshigoe/brick_ftp/compare/v0.8.2...v0.8.3)
 ----
 
-[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v0.8.2...master)
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v0.8.2...v0.8.3)
 
 ### Enhancements:
+
+- [#114](https://github.com/koshigoe/brick_ftp/pull/114) Allow to upload file using `StringIO`
 
 ### Fixed Bugs:
 
 ### Breaking Changes:
+
+### Others
 
 
 [0.8.2](https://github.com/koshigoe/brick_ftp/compare/v0.8.1...v0.8.2)

--- a/lib/brick_ftp/http_client.rb
+++ b/lib/brick_ftp/http_client.rb
@@ -99,7 +99,7 @@ module BrickFTP
       case
       when params.is_a?(Hash)
         req.body = params.to_json unless params.empty?
-      when params.is_a?(IO)
+      when params.is_a?(IO) || params.is_a?(StringIO)
         req.body_stream = params
         req['Content-Length'] = params.size
       end

--- a/lib/brick_ftp/http_client.rb
+++ b/lib/brick_ftp/http_client.rb
@@ -80,8 +80,7 @@ module BrickFTP
 
     private
 
-    # FIXME: Metrics/AbcSize, Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def request(method, path, params: {}, headers: {})
       req = Net::HTTP.const_get(method.to_s.capitalize).new(path, headers)
       req['User-Agent'] = USER_AGENT
@@ -122,7 +121,7 @@ module BrickFTP
         logger.info message
       end
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     def logger
       BrickFTP.logger

--- a/lib/brick_ftp/utils/chunk_io.rb
+++ b/lib/brick_ftp/utils/chunk_io.rb
@@ -20,7 +20,7 @@ module BrickFTP
       # Iterate with chunked IO object.
       #
       # @yield [chunk] Give a chunk IO object to block.
-      # @yieldparam [StringIO] chunk a chunked IO object.
+      # @yieldparam [IO] chunk a chunked IO object.
       #
       def each(&block)
         return enum_for(__method__) unless block

--- a/lib/brick_ftp/utils/chunk_io.rb
+++ b/lib/brick_ftp/utils/chunk_io.rb
@@ -9,8 +9,9 @@ module BrickFTP
 
       # Wrap IO object.
       #
-      # @param [IO] io an IO object.
+      # @param [IO, StringIO] io an IO object.
       # @param [Integer] chunk_size Size of chunk.
+      #   This option is ignored if `io` is `StringIO`.
       #
       def initialize(io, chunk_size: nil)
         @io = io
@@ -25,7 +26,7 @@ module BrickFTP
       def each(&block)
         return enum_for(__method__) unless block
 
-        if chunk_size
+        if chunk_size && io.is_a?(IO)
           each_chunk(&block)
         else
           whole(&block)

--- a/lib/brick_ftp/version.rb
+++ b/lib/brick_ftp/version.rb
@@ -1,3 +1,3 @@
 module BrickFTP
-  VERSION = '0.8.2'.freeze
+  VERSION = '0.8.3'.freeze
 end

--- a/spec/brick_ftp/utils/chunk_io_spec.rb
+++ b/spec/brick_ftp/utils/chunk_io_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe BrickFTP::Utils::ChunkIO do
     end
 
     context 'chunk_size is not nil' do
-      it 'split by chunk_size' do
-        Tempfile.create('spec') do |io|
-          io.write('DATA')
+      context 'data is a StringIO' do
+        it 'chunk has whole data' do
+          io = StringIO.new('DATA')
           io.rewind
 
           res = ''
@@ -34,7 +34,25 @@ RSpec.describe BrickFTP::Utils::ChunkIO do
             called += 1
           end
           expect(res).to eq 'DATA'
-          expect(called).to eq 4
+          expect(called).to eq 1
+        end
+      end
+
+      context 'data is not a StringIO' do
+        it 'split by chunk_size' do
+          Tempfile.create('spec') do |io|
+            io.write('DATA')
+            io.rewind
+
+            res = ''
+            called = 0
+            described_class.new(io, chunk_size: 1).each do |chunk|
+              res << chunk.read
+              called += 1
+            end
+            expect(res).to eq 'DATA'
+            expect(called).to eq 4
+          end
         end
       end
     end


### PR DESCRIPTION
## What did you implement:

ref #110

Allow to upload file using `StringIO`.

## How did you implement it:

Fix `BrickFTP::Utils::ChunkIO.new` to accept `StringIO` with `chunk_size:` option.

## How can we verify it:

```
$ bin/console
BrickFTP::API::FileOperation::Upload.create(
  path: 'test-koshigoe/issue_110.txt',
  source: StringIO.new('a' * 5_242_880 + 'b'),
  chunk_size: 5_242_880
)
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
