### PR TITLE
allow to ignore undefined attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,28 @@ Changelog
 ====
 
 
-[unreleased](https://github.com/koshigoe/brick_ftp/compare/v1.0.0...master)
+[unreleased](https://github.com/koshigoe/brick_ftp/compare/v1.0.1...master)
 ----
 
-[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v1.0.0...master)
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v1.0.1...master)
 
 ### Enhancements:
 
 ### Fixed Bugs:
+
+### Breaking Changes:
+
+
+[v1.0.1](https://github.com/koshigoe/brick_ftp/compare/v1.0.0...v1.0.1)
+----
+
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v1.0.0...v1.0.1)
+
+### Enhancements:
+
+### Fixed Bugs:
+
+- [#117](https://github.com/koshigoe/brick_ftp/pull/117) Ignore undefined attributes.
 
 ### Breaking Changes:
 

--- a/lib/brick_ftp.rb
+++ b/lib/brick_ftp.rb
@@ -6,6 +6,7 @@ require 'brick_ftp/core_ext'
 require 'brick_ftp/utils'
 require 'brick_ftp/utils/chunk_io'
 require 'brick_ftp/types'
+require 'brick_ftp/types/ignore_undefined_attributes'
 require 'brick_ftp/restful_api'
 
 module BrickFTP

--- a/lib/brick_ftp/types/behavior.rb
+++ b/lib/brick_ftp/types/behavior.rb
@@ -22,6 +22,8 @@ module BrickFTP
       :behavior,
       :value,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/bundle.rb
+++ b/lib/brick_ftp/types/bundle.rb
@@ -29,6 +29,8 @@ module BrickFTP
       :expires_at,
       :username,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/bundle_content.rb
+++ b/lib/brick_ftp/types/bundle_content.rb
@@ -20,6 +20,8 @@ module BrickFTP
       :type,
       :size,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/bundle_zip.rb
+++ b/lib/brick_ftp/types/bundle_zip.rb
@@ -14,6 +14,8 @@ module BrickFTP
       'BundleZip',
       :download_uri,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/file.rb
+++ b/lib/brick_ftp/types/file.rb
@@ -40,6 +40,8 @@ module BrickFTP
       :download_uri,
       :subfolders_locked?,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/file_in_bundle.rb
+++ b/lib/brick_ftp/types/file_in_bundle.rb
@@ -20,6 +20,8 @@ module BrickFTP
       :size,
       :download_uri,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/folder_contents_count.rb
+++ b/lib/brick_ftp/types/folder_contents_count.rb
@@ -19,6 +19,8 @@ module BrickFTP
       :files,
       :folders,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/group.rb
+++ b/lib/brick_ftp/types/group.rb
@@ -26,6 +26,8 @@ module BrickFTP
       :usernames,
       :admin_ids,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/group_membership.rb
+++ b/lib/brick_ftp/types/group_membership.rb
@@ -22,6 +22,8 @@ module BrickFTP
       :user_id,
       :admin,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/history.rb
+++ b/lib/brick_ftp/types/history.rb
@@ -38,6 +38,8 @@ module BrickFTP
       :ip,
       :interface,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/ignore_undefined_attributes.rb
+++ b/lib/brick_ftp/types/ignore_undefined_attributes.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module BrickFTP
+  module Types
+    module IgnoreUndefinedAttributes
+      def initialize(**kwargs)
+        super(**members.each_with_object({}) { |k, m| m[k] = kwargs[k] })
+      end
+    end
+  end
+end

--- a/lib/brick_ftp/types/notification.rb
+++ b/lib/brick_ftp/types/notification.rb
@@ -26,6 +26,8 @@ module BrickFTP
       :send_interval,
       :unsubscribed,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/permission.rb
+++ b/lib/brick_ftp/types/permission.rb
@@ -30,6 +30,8 @@ module BrickFTP
       :permission,
       :recursive,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/site_usage.rb
+++ b/lib/brick_ftp/types/site_usage.rb
@@ -18,6 +18,8 @@ module BrickFTP
       :total_uploads,
       :total_downloads,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/upload.rb
+++ b/lib/brick_ftp/types/upload.rb
@@ -40,6 +40,8 @@ module BrickFTP
       :expires,
       :next_partsize,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/user.rb
+++ b/lib/brick_ftp/types/user.rb
@@ -74,6 +74,8 @@ module BrickFTP
       :lockout_expires,
       :admin_group_ids,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/user_api_key.rb
+++ b/lib/brick_ftp/types/user_api_key.rb
@@ -28,6 +28,8 @@ module BrickFTP
       :expires_at,
       :created_at,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/types/user_public_key.rb
+++ b/lib/brick_ftp/types/user_public_key.rb
@@ -23,6 +23,8 @@ module BrickFTP
       :fingerprint,
       :created_at,
       keyword_init: true
-    )
+    ) do
+      prepend IgnoreUndefinedAttributes
+    end
   end
 end

--- a/lib/brick_ftp/version.rb
+++ b/lib/brick_ftp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrickFTP
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
## What did you implement:

When BrickFTP add new attribute, brick_ftp gem will hung up...

## How did you implement it:

Ignore undefined attributes in brick_ftp gem.

## How can we verify it:

Pass CI.

## Todos:

- ~~Write tests~~
- ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ x Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
