### PR TITLE
[chore][experimental] Add GitHub workflow for release

### DIFF
--- a/.github/action/publish_gem/Dockerfile
+++ b/.github/action/publish_gem/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:alpine
+LABEL "com.github.actions.name"="Publish Gem"
+LABEL "com.github.actions.description"="Publish gem to rubygems.org"
+LABEL "com.github.actions.icon"="truck"
+LABEL "com.github.actions.color"="green"
+LABEL "repository"="https://github.com/koshigoe/brick_ftp"
+LABEL "homepage"="https://github.com/koshigoe/brick_ftp"
+LABEL "maintainer"="koshigoe <koshigoeb@gmail.com>"
+
+RUN apk update -q \
+        && apk add -q --no-cache curl jq git
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/action/publish_gem/entrypoint.sh
+++ b/.github/action/publish_gem/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/ash -eu
+
+cd $GITHUB_WORKSPACE
+
+mkdir -p ~/.gem
+cat <<EOF > ~/.gem/credentials
+---
+:rubygems_api_key: $RUBYGEMS_TOKEN
+EOF
+chmod 0600 ~/.gem/credentials
+
+gem build *.gemspec
+gem push *.gem

--- a/.github/action/write_github_release/Dockerfile
+++ b/.github/action/write_github_release/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.8
+LABEL "com.github.actions.name"="Write GitHub Release"
+LABEL "com.github.actions.description"="Write merged PRs into latest GitHub Release"
+LABEL "com.github.actions.icon"="edit"
+LABEL "com.github.actions.color"="blue"
+LABEL "repository"="https://github.com/koshigoe/brick_ftp"
+LABEL "homepage"="https://github.com/koshigoe/brick_ftp"
+LABEL "maintainer"="koshigoe <koshigoeb@gmail.com>"
+
+RUN apk update -q \
+        && apk add -q --no-cache curl jq
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/action/write_github_release/entrypoint.sh
+++ b/.github/action/write_github_release/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/ash -eu
+
+# Get previous GitHub Release.
+curl --fail -s \
+     -u $GITHUB_ACTOR:$GITHUB_TOKEN \
+     https://api.github.com/repos/$GITHUB_REPOSITORY/releases \
+    | jq -r '.[1]' \
+     > previous_release.json
+previous_published_date=$(jq -r '.published_at' previous_release.json)
+
+# Get latest published date.
+latest_published_date=$(jq -r '.release.published_at' $GITHUB_EVENT_PATH)
+
+# Get latest GitHub Release ID.
+latest_release_id=$(jq -r '.release.id' $GITHUB_EVENT_PATH)
+
+# Get merged PRs
+merged_pr_list=$(
+    curl --fail -s \
+         -u $GITHUB_ACTOR:$GITHUB_TOKEN \
+         "https://api.github.com/search/issues?q=repo:${GITHUB_REPOSITORY}+is:pr+base:master+merged:${previous_published_date}..${latest_published_date}" \
+        | jq -r '.items[] | ["- #" + (.number | tostring) + " " + .title] | @tsv' \
+        | sort -k 3)
+
+# Get comparable tags
+previous_tag_name=$(jq -r '.tag_name' previous_release.json)
+latest_tag_name=$(jq -r '.release.tag_name' $GITHUB_EVENT_PATH)
+
+# Make release note.
+release_note=$(cat <<EOF | sed ':a;N;$!ba;s/\n/\\n/g')
+https://github.com/$GITHUB_REPOSITORY/compare/${previous_tag_name}...${latest_tag_name}
+
+### Merged
+
+$merged_pr_list
+EOF
+
+# Update body of latest GitHub Release.
+curl --fail -s \
+     -u $GITHUB_ACTOR:$GITHUB_TOKEN \
+     -X PATCH \
+     -d "{\"body\":\"${release_note}\"}" \
+     https://api.github.com/repos/$GITHUB_REPOSITORY/releases/$latest_release_id

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,14 @@
+workflow "Release" {
+  on = "release"
+  resolves = ["Write GitHub Release", "Publish Gem"]
+}
+
+action "Write GitHub Release" {
+  uses = "./.github/action/write_github_release"
+  secrets = ["GITHUB_TOKEN"]
+}
+
+action "Publish Gem" {
+  uses = "./.github/action/publish_gem"
+  secrets = ["GITHUB_TOKEN", "RUBYGEMS_TOKEN"]
+}


### PR DESCRIPTION
## What did you implement:

Add GitHub Actions and Workflow to improve my release flow.

## How did you implement it:

New release flow:

1. create and merge PR to bump up version.
1. create GitHub Release named version.
1. a GitHub Action is triggered to update GitHub Release.
1. a GitHub Action is triggered to build and ship gem.

## How can we verify it:

https://github.com/koshigoe/koshigoe_gem_playground/actions/workflow-runs/MDEwOkNoZWNrU3VpdGU4MzA5MjU0Nw==

## Todos:

- [ ] ~~Write tests~~
- [ ] ~~Write documentation~~
- [ ] ~~Fix linting errors~~
- [ ] ~~Make sure code coverage hasn't dropped~~
- [ ] ~~Provide verification config / commands / resources~~
- [ ] ~~Enable "Allow edits from maintainers" for this PR~~
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
