### PR TITLE
Handle response 204 Not Content

### DIFF
--- a/lib/brick_ftp/restful_api/client.rb
+++ b/lib/brick_ftp/restful_api/client.rb
@@ -153,6 +153,8 @@ module BrickFTP
 
       def handle_response(response)
         case response
+        when Net::HTTPNoContent
+          nil
         when Net::HTTPSuccess
           parse_success_response(response)
         else

--- a/spec/brick_ftp/restful_api/create_folder_spec.rb
+++ b/spec/brick_ftp/restful_api/create_folder_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BrickFTP::RESTfulAPI::CreateFolder, type: :lib do
               'User-Agent' => 'BrickFTP Client/1.0 (https://github.com/koshigoe/brick_ftp)',
             }
           )
-          .to_return(body: '[]')
+          .to_return(body: nil, status: 204)
 
         rest = BrickFTP::RESTfulAPI::Client.new('subdomain', 'api-key')
         command = BrickFTP::RESTfulAPI::CreateFolder.new(rest)


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/koshigoe/brick_ftp#contributing
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Some API response changed.
They return 204 Not Content (with empty body).
So, `JSON.parse(nil)` raise exception.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Fix to handle response 204 Not Content.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] ~~Write documentation~~
- [ ] ~~Fix linting errors~~
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
