### PR TITLE
Suppress warnings in Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,10 @@ jobs:
     <<: *build
     docker:
       - image: circleci/ruby:2.6
+  ruby-2.7:
+    <<: *build
+    docker:
+      - image: circleci/ruby:2.7
 
 workflows:
   version: 2
@@ -43,3 +47,4 @@ workflows:
       - ruby-2.4
       - ruby-2.5
       - ruby-2.6
+      - ruby-2.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,21 +15,9 @@ jobs:
       - run:
           name: YARDoc
           command: yardoc --fail-on-warning lib
-      # see https://docs.codeclimate.com/docs/circle-ci-test-coverage-example
-      - run:
-          name: Setup Code Climate test-reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
       - run:
           name: RSpec
-          command: |
-            ./cc-test-reporter before-build
-            rspec
-            ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
-      - store_artifacts:
-          path: coverage
-          destination: coverage
+          command: rspec
   ruby-2.3:
     <<: *build
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
   ruby-2.6:
     <<: *build
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.6
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ Files::User.new(params, api_key: 'YOUR_API_KEY')
 I will archive this repository after found official SDK.
 
 
+[v2.0.2](https://github.com/koshigoe/brick_ftp/compare/v2.0.1...v2.0.2)
+----
+
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v2.0.1...v2.0.2)
+
+### Enhancements:
+
+- [#132](https://github.com/koshigoe/brick_ftp/pull/132) Suppress warnings in Ruby 2.7
+
+### Fixed Bugs:
+
+### Breaking Changes:
+
+
 [v2.0.1](https://github.com/koshigoe/brick_ftp/compare/v2.0.0...v2.0.1)
 ----
 

--- a/brick_ftp.gemspec
+++ b/brick_ftp.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'pry', '~> 0.11'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4'

--- a/lib/brick_ftp/restful_api/add_group_member.rb
+++ b/lib/brick_ftp/restful_api/add_group_member.rb
@@ -37,7 +37,7 @@ module BrickFTP
       def call(group_id, user_id, params)
         res = client.put("/api/rest/v1/groups/#{group_id}/memberships/#{user_id}.json", membership: params.to_h.compact)
 
-        BrickFTP::Types::GroupMembership.new(res.symbolize_keys)
+        BrickFTP::Types::GroupMembership.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/complete_upload.rb
+++ b/lib/brick_ftp/restful_api/complete_upload.rb
@@ -39,7 +39,7 @@ module BrickFTP
       def call(path, params)
         res = client.post("/api/rest/v1/files/#{ERB::Util.url_encode(path)}", params.to_h.compact.merge(action: 'end'))
 
-        BrickFTP::Types::File.new(res.symbolize_keys)
+        BrickFTP::Types::File.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/continue_upload.rb
+++ b/lib/brick_ftp/restful_api/continue_upload.rb
@@ -43,7 +43,7 @@ module BrickFTP
       def call(path, params)
         res = client.post("/api/rest/v1/files/#{ERB::Util.url_encode(path)}", params.to_h.compact.merge(action: 'put'))
 
-        BrickFTP::Types::Upload.new(res.symbolize_keys)
+        BrickFTP::Types::Upload.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/count_folder_contents.rb
+++ b/lib/brick_ftp/restful_api/count_folder_contents.rb
@@ -29,7 +29,7 @@ module BrickFTP
         if recursive
           BrickFTP::Types::FolderContentsCount.new(total: res['data']['count'])
         else
-          BrickFTP::Types::FolderContentsCount.new(res['data']['count'].symbolize_keys)
+          BrickFTP::Types::FolderContentsCount.new(**res['data']['count'].symbolize_keys)
         end
       end
     end

--- a/lib/brick_ftp/restful_api/create_api_key.rb
+++ b/lib/brick_ftp/restful_api/create_api_key.rb
@@ -39,7 +39,7 @@ module BrickFTP
       def call(id, params)
         res = client.post("/api/rest/v1/users/#{id}/api_keys.json", params.to_h.compact)
 
-        BrickFTP::Types::UserAPIKey.new(res.symbolize_keys)
+        BrickFTP::Types::UserAPIKey.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/create_behavior.rb
+++ b/lib/brick_ftp/restful_api/create_behavior.rb
@@ -35,7 +35,7 @@ module BrickFTP
       def call(params)
         res = client.post('/api/rest/v1/behaviors.json', params.to_h.compact)
 
-        BrickFTP::Types::Behavior.new(res.symbolize_keys)
+        BrickFTP::Types::Behavior.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/create_bundle.rb
+++ b/lib/brick_ftp/restful_api/create_bundle.rb
@@ -33,7 +33,7 @@ module BrickFTP
       def call(params)
         res = client.post('/api/rest/v1/bundles.json', params.to_h.compact)
 
-        BrickFTP::Types::Bundle.new(res.symbolize_keys)
+        BrickFTP::Types::Bundle.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/create_group.rb
+++ b/lib/brick_ftp/restful_api/create_group.rb
@@ -35,7 +35,7 @@ module BrickFTP
       def call(params)
         res = client.post('/api/rest/v1/groups.json', params.to_h.compact)
 
-        BrickFTP::Types::Group.new(res.symbolize_keys)
+        BrickFTP::Types::Group.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/create_notification.rb
+++ b/lib/brick_ftp/restful_api/create_notification.rb
@@ -37,7 +37,7 @@ module BrickFTP
       def call(params)
         res = client.post('/api/rest/v1/notifications.json', params.to_h.compact)
 
-        BrickFTP::Types::Notification.new(res.symbolize_keys)
+        BrickFTP::Types::Notification.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/create_permission.rb
+++ b/lib/brick_ftp/restful_api/create_permission.rb
@@ -41,7 +41,7 @@ module BrickFTP
       def call(params)
         res = client.post('/api/rest/v1/permissions.json', params.to_h.compact)
 
-        BrickFTP::Types::Permission.new(res.symbolize_keys)
+        BrickFTP::Types::Permission.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/create_public_key.rb
+++ b/lib/brick_ftp/restful_api/create_public_key.rb
@@ -35,7 +35,7 @@ module BrickFTP
       def call(id, params)
         res = client.post("/api/rest/v1/users/#{id}/public_keys.json", params.to_h.compact)
 
-        BrickFTP::Types::UserPublicKey.new(res.symbolize_keys)
+        BrickFTP::Types::UserPublicKey.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/create_user.rb
+++ b/lib/brick_ftp/restful_api/create_user.rb
@@ -83,7 +83,7 @@ module BrickFTP
       def call(params)
         res = client.post('/api/rest/v1/users.json', params.to_h.compact)
 
-        BrickFTP::Types::User.new(res.symbolize_keys)
+        BrickFTP::Types::User.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/create_user_in_group.rb
+++ b/lib/brick_ftp/restful_api/create_user_in_group.rb
@@ -53,7 +53,7 @@ module BrickFTP
       def call(id, params)
         res = client.post("/api/rest/v1/groups/#{id}/users.json", user: params.to_h.compact)
 
-        BrickFTP::Types::User.new(res.symbolize_keys)
+        BrickFTP::Types::User.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/download_file.rb
+++ b/lib/brick_ftp/restful_api/download_file.rb
@@ -38,7 +38,7 @@ module BrickFTP
         res = client.get(endpoint)
         return nil if !res || res.empty?
 
-        BrickFTP::Types::File.new(res.symbolize_keys)
+        BrickFTP::Types::File.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/get_api_key.rb
+++ b/lib/brick_ftp/restful_api/get_api_key.rb
@@ -19,7 +19,7 @@ module BrickFTP
       def call(id)
         res = client.get("/api/rest/v1/api_keys/#{id}.json")
 
-        BrickFTP::Types::UserAPIKey.new(res.symbolize_keys)
+        BrickFTP::Types::UserAPIKey.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/get_behavior.rb
+++ b/lib/brick_ftp/restful_api/get_behavior.rb
@@ -19,7 +19,7 @@ module BrickFTP
         res = client.get("/api/rest/v1/behaviors/#{id}.json")
         return nil if !res || res.empty?
 
-        BrickFTP::Types::Behavior.new(res.symbolize_keys)
+        BrickFTP::Types::Behavior.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/get_bundle.rb
+++ b/lib/brick_ftp/restful_api/get_bundle.rb
@@ -19,7 +19,7 @@ module BrickFTP
         res = client.get("/api/rest/v1/bundles/#{id}.json")
         return nil if !res || res.empty?
 
-        BrickFTP::Types::Bundle.new(res.symbolize_keys)
+        BrickFTP::Types::Bundle.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/get_bundle_zip.rb
+++ b/lib/brick_ftp/restful_api/get_bundle_zip.rb
@@ -41,7 +41,7 @@ module BrickFTP
       def call(params)
         res = client.post('/api/rest/v1/bundles/zip.json', params.to_h.compact)
 
-        BrickFTP::Types::BundleZip.new(res.symbolize_keys)
+        BrickFTP::Types::BundleZip.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/get_file_in_bundle.rb
+++ b/lib/brick_ftp/restful_api/get_file_in_bundle.rb
@@ -42,7 +42,7 @@ module BrickFTP
       def call(params)
         res = client.post('/api/rest/v1/bundles/download.json', params.to_h.compact)
 
-        BrickFTP::Types::FileInBundle.new(res.symbolize_keys)
+        BrickFTP::Types::FileInBundle.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/get_group.rb
+++ b/lib/brick_ftp/restful_api/get_group.rb
@@ -20,7 +20,7 @@ module BrickFTP
         res = client.get("/api/rest/v1/groups/#{id}.json")
         return nil if !res || res.empty?
 
-        BrickFTP::Types::Group.new(res.symbolize_keys)
+        BrickFTP::Types::Group.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/get_public_key.rb
+++ b/lib/brick_ftp/restful_api/get_public_key.rb
@@ -19,7 +19,7 @@ module BrickFTP
       def call(id)
         res = client.get("/api/rest/v1/public_keys/#{id}.json")
 
-        BrickFTP::Types::UserPublicKey.new(res.symbolize_keys)
+        BrickFTP::Types::UserPublicKey.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/get_site_usage.rb
+++ b/lib/brick_ftp/restful_api/get_site_usage.rb
@@ -13,7 +13,7 @@ module BrickFTP
       def call
         res = client.get('/api/rest/v1/site/usage.json')
 
-        BrickFTP::Types::SiteUsage.new(res.symbolize_keys)
+        BrickFTP::Types::SiteUsage.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/get_user.rb
+++ b/lib/brick_ftp/restful_api/get_user.rb
@@ -20,7 +20,7 @@ module BrickFTP
         res = client.get("/api/rest/v1/users/#{id}.json")
         return nil if !res || res.empty?
 
-        BrickFTP::Types::User.new(res.symbolize_keys)
+        BrickFTP::Types::User.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/list_api_keys.rb
+++ b/lib/brick_ftp/restful_api/list_api_keys.rb
@@ -19,7 +19,7 @@ module BrickFTP
       def call(id)
         res = client.get("/api/rest/v1/users/#{id}/api_keys.json")
 
-        res.map { |i| BrickFTP::Types::UserAPIKey.new(i.symbolize_keys) }
+        res.map { |i| BrickFTP::Types::UserAPIKey.new(**i.symbolize_keys) }
       end
     end
   end

--- a/lib/brick_ftp/restful_api/list_behaviors.rb
+++ b/lib/brick_ftp/restful_api/list_behaviors.rb
@@ -17,7 +17,7 @@ module BrickFTP
       def call
         res = client.get('/api/rest/v1/behaviors.json')
 
-        res.map { |i| BrickFTP::Types::Behavior.new(i.symbolize_keys) }
+        res.map { |i| BrickFTP::Types::Behavior.new(**i.symbolize_keys) }
       end
     end
   end

--- a/lib/brick_ftp/restful_api/list_bundle_contents.rb
+++ b/lib/brick_ftp/restful_api/list_bundle_contents.rb
@@ -51,7 +51,7 @@ module BrickFTP
                    end
         res = client.post(endpoint, params.to_h.compact)
 
-        res.map { |i| BrickFTP::Types::BundleContent.new(i.symbolize_keys) }
+        res.map { |i| BrickFTP::Types::BundleContent.new(**i.symbolize_keys) }
       end
     end
   end

--- a/lib/brick_ftp/restful_api/list_bundles.rb
+++ b/lib/brick_ftp/restful_api/list_bundles.rb
@@ -17,7 +17,7 @@ module BrickFTP
       def call
         res = client.get('/api/rest/v1/bundles.json')
 
-        res.map { |i| BrickFTP::Types::Bundle.new(i.symbolize_keys) }
+        res.map { |i| BrickFTP::Types::Bundle.new(**i.symbolize_keys) }
       end
     end
   end

--- a/lib/brick_ftp/restful_api/list_folder_behaviors.rb
+++ b/lib/brick_ftp/restful_api/list_folder_behaviors.rb
@@ -33,7 +33,7 @@ module BrickFTP
         endpoint = "#{endpoint}?recursive=1" if recursive
         res = client.get(endpoint)
 
-        res.map { |i| BrickFTP::Types::Behavior.new(i.symbolize_keys) }
+        res.map { |i| BrickFTP::Types::Behavior.new(**i.symbolize_keys) }
       end
     end
   end

--- a/lib/brick_ftp/restful_api/list_folders.rb
+++ b/lib/brick_ftp/restful_api/list_folders.rb
@@ -59,7 +59,7 @@ module BrickFTP
 
         res = client.get(endpoint)
 
-        res.map { |i| BrickFTP::Types::File.new(i.symbolize_keys) }
+        res.map { |i| BrickFTP::Types::File.new(**i.symbolize_keys) }
       end
 
       private

--- a/lib/brick_ftp/restful_api/list_groups.rb
+++ b/lib/brick_ftp/restful_api/list_groups.rb
@@ -17,7 +17,7 @@ module BrickFTP
       def call
         res = client.get('/api/rest/v1/groups.json')
 
-        res.map { |i| BrickFTP::Types::Group.new(i.symbolize_keys) }
+        res.map { |i| BrickFTP::Types::Group.new(**i.symbolize_keys) }
       end
     end
   end

--- a/lib/brick_ftp/restful_api/list_notifications.rb
+++ b/lib/brick_ftp/restful_api/list_notifications.rb
@@ -17,7 +17,7 @@ module BrickFTP
       def call
         res = client.get('/api/rest/v1/notifications.json')
 
-        res.map { |i| BrickFTP::Types::Notification.new(i.symbolize_keys) }
+        res.map { |i| BrickFTP::Types::Notification.new(**i.symbolize_keys) }
       end
     end
   end

--- a/lib/brick_ftp/restful_api/list_permissions.rb
+++ b/lib/brick_ftp/restful_api/list_permissions.rb
@@ -35,7 +35,7 @@ module BrickFTP
         endpoint = "#{endpoint}?path=#{ERB::Util.url_encode(path)}" unless path.nil?
         res = client.get(endpoint)
 
-        res.map { |i| BrickFTP::Types::Permission.new(i.symbolize_keys) }
+        res.map { |i| BrickFTP::Types::Permission.new(**i.symbolize_keys) }
       end
     end
   end

--- a/lib/brick_ftp/restful_api/list_public_keys.rb
+++ b/lib/brick_ftp/restful_api/list_public_keys.rb
@@ -19,7 +19,7 @@ module BrickFTP
       def call(id)
         res = client.get("/api/rest/v1/users/#{id}/public_keys.json")
 
-        res.map { |i| BrickFTP::Types::UserPublicKey.new(i.symbolize_keys) }
+        res.map { |i| BrickFTP::Types::UserPublicKey.new(**i.symbolize_keys) }
       end
     end
   end

--- a/lib/brick_ftp/restful_api/list_users.rb
+++ b/lib/brick_ftp/restful_api/list_users.rb
@@ -38,7 +38,7 @@ module BrickFTP
         endpoint = "#{endpoint}?#{query}" unless query.empty?
         res = client.get(endpoint)
 
-        res.map { |i| BrickFTP::Types::User.new(i.symbolize_keys) }
+        res.map { |i| BrickFTP::Types::User.new(**i.symbolize_keys) }
       end
 
       private

--- a/lib/brick_ftp/restful_api/retrieve_history.rb
+++ b/lib/brick_ftp/restful_api/retrieve_history.rb
@@ -17,7 +17,7 @@ module BrickFTP
         endpoint = "#{path}?#{query}" unless query.empty?
         res = client.get(endpoint)
 
-        res.map { |i| BrickFTP::Types::History.new(i.symbolize_keys) }
+        res.map { |i| BrickFTP::Types::History.new(**i.symbolize_keys) }
       end
 
       def validate_page!(page)

--- a/lib/brick_ftp/restful_api/search_user.rb
+++ b/lib/brick_ftp/restful_api/search_user.rb
@@ -22,7 +22,7 @@ module BrickFTP
         res = client.get("/api/rest/v1/users.json?q[username]=#{ERB::Util.url_encode(username)}")
         return nil if !res || res.empty?
 
-        BrickFTP::Types::User.new(res.first.symbolize_keys)
+        BrickFTP::Types::User.new(**res.first.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/start_upload.rb
+++ b/lib/brick_ftp/restful_api/start_upload.rb
@@ -21,7 +21,7 @@ module BrickFTP
       def call(path)
         res = client.post("/api/rest/v1/files/#{ERB::Util.url_encode(path)}", action: 'put')
 
-        BrickFTP::Types::Upload.new(res.symbolize_keys)
+        BrickFTP::Types::Upload.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/unlock_user.rb
+++ b/lib/brick_ftp/restful_api/unlock_user.rb
@@ -19,7 +19,7 @@ module BrickFTP
       def call(id)
         res = client.post("/api/rest/v1/users/#{id}/unlock.json")
 
-        BrickFTP::Types::User.new(res.symbolize_keys)
+        BrickFTP::Types::User.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/update_behavior.rb
+++ b/lib/brick_ftp/restful_api/update_behavior.rb
@@ -32,7 +32,7 @@ module BrickFTP
       def call(id, params)
         res = client.patch("/api/rest/v1/behaviors/#{id}.json", params.to_h.compact)
 
-        BrickFTP::Types::Behavior.new(res.symbolize_keys)
+        BrickFTP::Types::Behavior.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/update_group.rb
+++ b/lib/brick_ftp/restful_api/update_group.rb
@@ -37,7 +37,7 @@ module BrickFTP
       def call(id, params)
         res = client.put("/api/rest/v1/groups/#{id}.json", params.to_h.compact)
 
-        BrickFTP::Types::Group.new(res.symbolize_keys)
+        BrickFTP::Types::Group.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/update_group_member.rb
+++ b/lib/brick_ftp/restful_api/update_group_member.rb
@@ -33,7 +33,7 @@ module BrickFTP
       def call(group_id, user_id, params)
         res = client.patch("/api/rest/v1/groups/#{group_id}/memberships/#{user_id}.json", membership: params.to_h.compact)
 
-        BrickFTP::Types::GroupMembership.new(res.symbolize_keys)
+        BrickFTP::Types::GroupMembership.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/restful_api/update_user.rb
+++ b/lib/brick_ftp/restful_api/update_user.rb
@@ -94,7 +94,7 @@ module BrickFTP
       def call(id, params)
         res = client.put("/api/rest/v1/users/#{id}.json", params.to_h.compact)
 
-        BrickFTP::Types::User.new(res.symbolize_keys)
+        BrickFTP::Types::User.new(**res.symbolize_keys)
       end
     end
   end

--- a/lib/brick_ftp/version.rb
+++ b/lib/brick_ftp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrickFTP
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end


### PR DESCRIPTION
## What did you implement:

To suppress warnings bellow:

```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

## How did you implement it:

Use splat operator(`**`).

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
