### PR TITLE
Fix to enable to delete folder recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ Files::User.new(params, api_key: 'YOUR_API_KEY')
 I will archive this repository after found official SDK.
 
 
+[v2.0.3](https://github.com/koshigoe/brick_ftp/compare/v2.0.2...v2.0.3)
+----
+
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v2.0.2...v2.0.3)
+
+### Enhancements:
+
+### Fixed Bugs:
+
+- [#133](https://github.com/koshigoe/brick_ftp/pull/133) Fix to enable to delete folders recursively
+
+### Breaking Changes:
+
+
 [v2.0.2](https://github.com/koshigoe/brick_ftp/compare/v2.0.1...v2.0.2)
 ----
 

--- a/lib/brick_ftp/restful_api/delete_folder.rb
+++ b/lib/brick_ftp/restful_api/delete_folder.rb
@@ -6,25 +6,23 @@ module BrickFTP
   module RESTfulAPI
     # Delete a file or folder
     #
-    # @see https://developers.files.com/#delete-a-file-or-folder Delete a file or folder
+    # @see https://developers.files.com/#delete-file-folder Delete file/folder
     #
     class DeleteFolder
       include Command
 
       # Deletes a file or folder.
       #
-      # Note that this operation works for both files and folders, but normally it will only work on empty folders.
-      # If you want to recursively delete a folder and all its contents, send the request with a `Depth` header
-      # with the value set to `infinity`.
+      # > If true, will recursively delete folers. Otherwise, will error on non-empty folders.
       #
       # @param [String] path Full path of the file or folder. Maximum of 550 characters.
       # @param [Boolean] recursive
       #
       def call(path, recursive: false)
-        headers = {}
-        headers = { 'Depth' => 'infinity' } if recursive
+        url = "/api/rest/v1/files/#{ERB::Util.url_encode(path)}"
+        url += '?recursive=true' if recursive
 
-        client.delete("/api/rest/v1/files/#{ERB::Util.url_encode(path)}", headers)
+        client.delete(url)
         true
       end
     end

--- a/lib/brick_ftp/version.rb
+++ b/lib/brick_ftp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrickFTP
-  VERSION = '2.0.2'
+  VERSION = '2.0.3'
 end

--- a/spec/brick_ftp/restful_api/delete_folder_spec.rb
+++ b/spec/brick_ftp/restful_api/delete_folder_spec.rb
@@ -6,12 +6,11 @@ RSpec.describe BrickFTP::RESTfulAPI::DeleteFolder, type: :lib do
   describe '#call' do
     context 'given correct parameters' do
       it 'delete folder' do
-        stub_request(:delete, 'https://subdomain.files.com/api/rest/v1/files/a%20b%2Fc')
+        stub_request(:delete, 'https://subdomain.files.com/api/rest/v1/files/a%20b%2Fc?recursive=true')
           .with(
             basic_auth: %w[api-key x],
             headers: {
               'User-Agent' => 'BrickFTP Client/1.0 (https://github.com/koshigoe/brick_ftp)',
-              'Depth' => 'infinity',
             }
           )
           .to_return(body: '[]')


### PR DESCRIPTION
## What did you implement:

> recursive | If true, will recursively delete folers. Otherwise, will error on non-empty folders.
> https://developers.files.com/#delete-file-folder

> ```
> curl "https://app.files.com/api/rest/v1/files/{path}.json?recursive=true" \
>   -X DELETE \
>   -H 'X-FilesAPI-Key: YOUR_API_KEY'
> ```

## How did you implement it:

Use query parameter `recursive=true` instead of request header `Depth`.

## How can we verify it:

```
$ bin/console
> api_client = BrickFTP::RESTfulAPI::Client.new(ENV['BRICK_FTP_SUBDOMAIN'], ENV['BRICK_FTP_API_KEY'])
> BrickFTP::RESTfulAPI::DeleteFolder.new(api_client).call('a', recursive: true)
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
