### PR TITLE
Update thor to 1.0 for rails 6.1.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,14 +21,6 @@ jobs:
       - store_artifacts:
           path: coverage
           destination: coverage
-  ruby-2.2:
-    <<: *build
-    docker:
-      - image: circleci/ruby:2.2
-  ruby-2.3:
-    <<: *build
-    docker:
-      - image: circleci/ruby:2.3
   ruby-2.4:
     <<: *build
     docker:
@@ -37,12 +29,15 @@ jobs:
     <<: *build
     docker:
       - image: circleci/ruby:2.5
+  ruby-2.6:
+    <<: *build
+    docker:
+      - image: circleci/ruby:2.6
 
 workflows:
   version: 2
   build-using-multi-rubies:
     jobs:
-      - ruby-2.2
-      - ruby-2.3
       - ruby-2.4
       - ruby-2.5
+      - ruby-2.6

--- a/brick_ftp.gemspec
+++ b/brick_ftp.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'deep_hash_transform', '~> 1.0'
   spec.add_dependency 'inifile', '~> 3.0.0'
-  spec.add_dependency 'thor', '~> 0.20'
+  spec.add_dependency 'thor', '~> 1.0'
 end


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/koshigoe/brick_ftp#contributing
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

* Update thor requirement to allow upgrade to rails 6.1.
* Also update circle CI to run ruby 2.4, 2.5, 2.6 due to bundler issue on older rubies:

```
#!/bin/bash -eo pipefail
bundle install
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "ruby":
  In Gemfile:
    ruby

    brick_ftp was resolved to 0.8.4, which depends on
      ruby (>= 2.2.0)

    bundler (~> 1.12) was resolved to 1.17.3, which depends on
      ruby (>= 1.8.7)

    codecov (~> 0.1.10) was resolved to 0.1.21, which depends on
      ruby (>= 2.4)

    pry (~> 0.10) was resolved to 0.13.1, which depends on
      ruby (>= 1.9.3)

    rubocop (~> 0.55.0) was resolved to 0.55.0, which depends on
      ruby (>= 2.1.0)

Exited with code exit status 6
CircleCI received exit code 6
```

## How did you implement it:

Updated requirement in gemspec.

## How can we verify it:

Confirmed CLI tools run with the new thor.

## Todos:

N/A

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
