### PR TITLE
Use `PATCH` method when update User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ Files::User.new(params, api_key: 'YOUR_API_KEY')
 I will archive this repository after found official SDK.
 
 
+[v2.1.1](https://github.com/koshigoe/brick_ftp/compare/v2.1.0...v2.1.1)
+----
+
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v2.1.0...v2.1.1)
+
+### Enhancements:
+
+- [#136](https://github.com/koshigoe/brick_ftp/pull/136) Use `PATCH` instead of `PUT` to update User.
+    - see https://developers.files.com/#update-user
+
+### Fixed Bugs:
+
+### Deprecate
+
+### Breaking Changes:
+
+
 [v2.1.0](https://github.com/koshigoe/brick_ftp/compare/v2.0.3...v2.1.0)
 ----
 

--- a/lib/brick_ftp/restful_api/update_user.rb
+++ b/lib/brick_ftp/restful_api/update_user.rb
@@ -92,7 +92,7 @@ module BrickFTP
       # @return [BrickFTP::Types::User] updated User
       #
       def call(id, params)
-        res = client.put("/api/rest/v1/users/#{id}.json", params.to_h.compact)
+        res = client.patch("/api/rest/v1/users/#{id}.json", params.to_h.compact)
 
         BrickFTP::Types::User.new(**res.symbolize_keys)
       end

--- a/lib/brick_ftp/version.rb
+++ b/lib/brick_ftp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrickFTP
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/spec/brick_ftp/restful_api/update_user_spec.rb
+++ b/spec/brick_ftp/restful_api/update_user_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe BrickFTP::RESTfulAPI::UpdateUser, type: :lib do
           admin_group_ids: []
         )
 
-        stub_request(:put, 'https://subdomain.files.com/api/rest/v1/users/1234.json')
+        stub_request(:patch, 'https://subdomain.files.com/api/rest/v1/users/1234.json')
           .with(
             basic_auth: %w[api-key x],
             headers: {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/koshigoe/brick_ftp#contributing
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

The mock server accept `Update User API` by `PATCH` method.
https://github.com/Files-com/files-mock-server/blob/bbfade80258b51509622192e0a32f38f478875e0/app/user_api.rb#L158

In API document, `Update User API` defined by `PATCH` method.
https://developers.files.com/#update-user

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Send API request by `PATCH` method.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

`BrickFTP::Client#update_user`

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
