### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,10 @@ jobs:
     <<: *build
     docker:
       - image: cimg/ruby:2.7
+  ruby-3.0:
+    <<: *build
+    docker:
+      - image: cimg/ruby:3.0
 
 workflows:
   version: 2
@@ -38,3 +42,4 @@ workflows:
       - ruby-2.5
       - ruby-2.6
       - ruby-2.7
+      - ruby-3.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build: &build
     docker:
-      - image: circleci/ruby:latest
+      - image: cimg/ruby:latest
     working_directory: /home/circleci/app
     steps:
       - checkout
@@ -21,15 +21,15 @@ jobs:
   ruby-2.5:
     <<: *build
     docker:
-      - image: circleci/ruby:2.5
+      - image: cimg/ruby:2.5
   ruby-2.6:
     <<: *build
     docker:
-      - image: circleci/ruby:2.6
+      - image: cimg/ruby:2.6
   ruby-2.7:
     <<: *build
     docker:
-      - image: circleci/ruby:2.7
+      - image: cimg/ruby:2.7
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,6 @@ jobs:
       - run:
           name: RSpec
           command: rspec
-  ruby-2.5:
-    <<: *build
-    docker:
-      - image: cimg/ruby:2.5
   ruby-2.6:
     <<: *build
     docker:
@@ -39,7 +35,6 @@ workflows:
   version: 2
   build-using-multi-rubies:
     jobs:
-      - ruby-2.5
       - ruby-2.6
       - ruby-2.7
       - ruby-3.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Style/EmptyCaseCondition:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,24 @@ Files::User.new(params, api_key: 'YOUR_API_KEY')
 I will archive this repository after found official SDK.
 
 
+[v2.1.2](https://github.com/koshigoe/brick_ftp/compare/v2.1.1...v2.1.2)
+----
+
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v2.1.1...v2.1.2)
+
+### Enhancements:
+
+- use `ruby2_keywords` to support Ruby 3.0.
+
+### Fixed Bugs:
+
+### Deprecate
+
+### Breaking Changes:
+
+- Dropping support for Ruby 2.5
+
+
 [v2.1.1](https://github.com/koshigoe/brick_ftp/compare/v2.1.0...v2.1.1)
 ----
 

--- a/brick_ftp.gemspec
+++ b/brick_ftp.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6.0'
 
+  spec.add_runtime_dependency 'ruby2_keywords'
+
   spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'pry', '~> 0.11'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/brick_ftp.gemspec
+++ b/brick_ftp.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'pry', '~> 0.11'

--- a/brick_ftp.gemspec
+++ b/brick_ftp.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4'
   spec.add_development_dependency 'rspec', '~> 3.7'
-  spec.add_development_dependency 'rubocop', '~> 0.57.0'
+  spec.add_development_dependency 'rubocop', '~> 1.23'
   spec.add_development_dependency 'simplecov', '~> 0.15'
   spec.add_development_dependency 'webmock', '~> 3.4'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/lib/brick_ftp/client.rb
+++ b/lib/brick_ftp/client.rb
@@ -58,9 +58,11 @@ module BrickFTP
         super
       end
     end
+    ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
     def dispatch_command(klass, *args)
       klass.new(api_client).call(*args)
     end
+    ruby2_keywords :dispatch_command if respond_to?(:ruby2_keywords, true)
   end
 end

--- a/lib/brick_ftp/version.rb
+++ b/lib/brick_ftp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrickFTP
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end

--- a/spec/brick_ftp/client_spec.rb
+++ b/spec/brick_ftp/client_spec.rb
@@ -81,6 +81,24 @@ RSpec.describe BrickFTP::Client, type: :lib do
         expect(client).to be_respond_to(:get_user)
         client.get_user(id)
       end
+
+      context 'API has keyword argument' do
+        it 'dispatch command' do
+          stub_request(:get, 'https://subdomain.files.com/api/rest/v1/folders/path?action=count')
+            .with(
+              basic_auth: %w[api-key x],
+              headers: {
+                'User-Agent' => 'BrickFTP Client/1.0 (https://github.com/koshigoe/brick_ftp)',
+              }
+            )
+            .to_return(body: { data: { count: 3 } }.to_json)
+
+          client = BrickFTP::Client.new(base_url: 'https://subdomain.files.com/', api_key: 'api-key')
+
+          res = client.count_folder_contents('path', recursive: true)
+          expect(res).to eq BrickFTP::Types::FolderContentsCount.new(total: 3)
+        end
+      end
     end
 
     context 'command not found' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+Warning[:deprecated] = true if Warning.respond_to?(:[]=)
+
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'simplecov'
 SimpleCov.start do


### PR DESCRIPTION
## What did you implement:

https://github.com/koshigoe/brick_ftp/blob/5648d8cd5594362bd9be557224a3a8ce334303b6/lib/brick_ftp/client.rb#L53-L64

In Ruby 2.7

```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

In Ruby 3.0

```
ArgumentError: wrong number of arguments ...
```



## How did you implement it:

use `ruby2_keywords`.

## How can we verify it:

Use Ruby 3.0.3:

```
$ rspec spec/brick_ftp/client_spec.rb:85
```

### Before

```
Failures:

  1) BrickFTP::Client delegate command found API has keyword argument dispatch command
     Failure/Error:
             def call(path, recursive: false)
               action = recursive ? 'count' : 'count_nrs'
               res = client.get("/api/rest/v1/folders/#{ERB::Util.url_encode(path)}?action=#{action}")

               if recursive
                 BrickFTP::Types::FolderContentsCount.new(total: res['data']['count'])
               else
                 BrickFTP::Types::FolderContentsCount.new(**res['data']['count'].symbolize_keys)
               end

     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ./lib/brick_ftp/restful_api/count_folder_contents.rb:25:in `call'
     # ./lib/brick_ftp/client.rb:64:in `dispatch_command'
     # ./lib/brick_ftp/client.rb:56:in `method_missing'
     # ./spec/brick_ftp/client_spec.rb:98:in `block (5 levels) in <top (required)>'
```

### After

```
BrickFTP::Client
  delegate
    command found
      API has keyword argument
        dispatch command

Finished in 0.01792 seconds (files took 0.39538 seconds to load)
1 example, 0 failures
```


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES (dropping support for Ruby 2.5)
