### PR TITLE
Filter unsupported keys included in error response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ Files::User.new(params, api_key: 'YOUR_API_KEY')
 I will archive this repository after found official SDK.
 
 
+[v2.1.3](https://github.com/koshigoe/brick_ftp/compare/v2.1.2...v2.1.3)
+----
+
+[Full Changelog](https://github.com/koshigoe/brick_ftp/compare/v2.1.2...v2.1.3)
+
+### Enhancements:
+
+### Fixed Bugs:
+
+- [#138](https://github.com/koshigoe/brick_ftp/pull/138) Filter unsupported keys included in error response
+
+### Deprecate
+
+### Breaking Changes:
+
+
 [v2.1.2](https://github.com/koshigoe/brick_ftp/compare/v2.1.1...v2.1.2)
 ----
 

--- a/lib/brick_ftp/restful_api/client.rb
+++ b/lib/brick_ftp/restful_api/client.rb
@@ -187,7 +187,7 @@ module BrickFTP
         end
         parsed = {} unless parsed.is_a?(Hash)
 
-        ErrorResponse.new(parsed.symbolize_keys).tap do |e|
+        ErrorResponse.new(parsed.symbolize_keys.slice(*ErrorResponse.members)).tap do |e|
           e['http-code'] ||= response.code
           e['error'] ||= response.body
         end

--- a/lib/brick_ftp/version.rb
+++ b/lib/brick_ftp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrickFTP
-  VERSION = '2.1.2'
+  VERSION = '2.1.3'
 end

--- a/spec/brick_ftp/restful_api/client_spec.rb
+++ b/spec/brick_ftp/restful_api/client_spec.rb
@@ -102,7 +102,16 @@ RSpec.describe BrickFTP::RESTfulAPI::Client, type: :lib do
             },
             body: '{}'
           )
-          .to_return(body: '{"error":"invalid","http-code":"400"}', status: 400)
+          .to_return(
+            body: {
+              'error' => 'invalid',
+              'http-code' => '400',
+              'instance' => 'a69f6b06-6ba9-4e71-8542-60d2ff3d96f2',
+              'title' => 'title',
+              'type' => 'type',
+            }.to_json,
+            status: 400
+          )
 
         rest = BrickFTP::RESTfulAPI::Client.new('subdomain', 'api-key')
         expect { rest.post('/path/to/resource.json', {}, 'Depth' => 'infinity') }


### PR DESCRIPTION
## What did you implement:

Takes unsupported keys.

https://github.com/koshigoe/brick_ftp/blob/98ce39f358bfbbda308e74f83c13fc5c5b60e1bf/lib/brick_ftp/restful_api/client.rb#L190
https://github.com/koshigoe/brick_ftp/blob/98ce39f358bfbbda308e74f83c13fc5c5b60e1bf/lib/brick_ftp/restful_api/client.rb#L17-L23

https://developers.files.com/#response-codes-errors

```json
{
   "error":"Invalid username or password",
   "http-code":401,
   "instance":"d895ebaa-7e7e-4ced-87c9-2acf743a19c3",
   "title":"Invalid Username Or Password",
   "type":"bad-request/invalid-username-or-password"
}
```

## How did you implement it:

Filter unsupported keys included in error response.

## How can we verify it:

RSpec.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
